### PR TITLE
feat: add workflow to publish tagged images of a branch and fix e2e route

### DIFF
--- a/.github/workflows/release-candidate.yaml
+++ b/.github/workflows/release-candidate.yaml
@@ -1,0 +1,76 @@
+# Release builds and publish a new release.
+
+# Secrets:
+# TEST_REGISTRY_USER: registry user for the container registry
+# TEST_REGISTRY_PASSWORD: password for container registry
+# Vars:
+# REGISTRY_URL: registry url for the container registry
+
+name: Publish Release Candidate
+
+on:
+    workflow_dispatch:
+      inputs:
+        nextVersion:
+          description: 'specify the release version in the semver format v[major].[minor].[patch] e.g. v0.0.0'
+          required: true
+
+# Releases need permissions to read and write the repository contents.
+# GitHub considers creating releases and uploading assets as writing contents.
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+    release:
+      runs-on: ubuntu-latest
+      steps:
+      - name: Set Version
+        id: version
+        run: echo "VERSION=fromPR-${{}}${{ github.event.inputs.nextVersion }}" >> $GITHUB_OUTPUT
+      - name: Print Version Number
+        run: echo "Effective version ${{ github.steps.version.outputs.VERSION }}"
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.4.0
+        with:
+          version: v0.15.1
+          install: true
+
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          submodules: true
+
+      - name: Fetch History
+        run: git fetch --prune --unshallow
+
+      - name: Set up Go
+        uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
+        with:
+          go-version: '1.21'
+
+      - name: Vendor Dependencies
+        run: make vendor vendor.check
+
+      - name: Build Images
+        run: make build VERSION=${{ github.steps.version.outputs.VERSION }}
+        env:
+          # We're using docker buildx, which doesn't actually load the images it
+          # builds by default. Specifying --load does so.
+          BUILD_ARGS: "--load"
+          DOCKER_REGISTRY: ${{ vars.REGISTRY_URL }}
+          BUILD_REGISTRY: ${{ vars.REGISTRY_URL }}
+
+      - name: Login to Container Registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ${{ vars.REGISTRY_URL }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish Artifacts to DockerHub
+        run: make publish VERSION=${{ github.steps.version.outputs.VERSION }}
+        env:
+          DOCKER_REGISTRY: ${{ vars.REGISTRY_URL }}
+          BUILD_REGISTRY: ${{ vars.REGISTRY_URL }}

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ PROJECT_REPO := github.com/SAP/$(PROJECT_NAME)
 
 
 PLATFORMS ?= linux_amd64 linux_arm64
+VERSION ?= $(shell git describe --tags --exact-match 2>/dev/null || git rev-parse HEAD)
+$(info VERSION is $(VERSION))
 
 # -include will silently skip missing files, which allows us
 # to load those files with a target in the Makefile. If only


### PR DESCRIPTION
This PR allows us to publish tagged images of a branch.

For further discussion look here:
https://github.com/SAP/crossplane-provider-btp/pull/138/files

This is needed for the upcoming TechTalk, where we want to enable users to directly try out MTAs without having it build into the main branch yet.

The release-candidate workflow has shared parts with the release workflow. Those could be (eventually) factored out to a shared action