### PR TITLE
fix: rc workflow

### DIFF
--- a/.github/workflows/release-candidate.yaml
+++ b/.github/workflows/release-candidate.yaml
@@ -9,11 +9,7 @@
 name: Publish Release Candidate
 
 on:
-    workflow_dispatch:
-      inputs:
-        nextVersion:
-          description: 'specify the release version in the semver format v[major].[minor].[patch] e.g. v0.0.0'
-          required: true
+    workflow_dispatch: {}
 
 # Releases need permissions to read and write the repository contents.
 # GitHub considers creating releases and uploading assets as writing contents.
@@ -25,22 +21,22 @@ jobs:
     release:
       runs-on: ubuntu-latest
       steps:
-      - name: Set Version
-        id: version
-        run: echo "VERSION=fromPR-${{}}${{ github.event.inputs.nextVersion }}" >> $GITHUB_OUTPUT
-      - name: Print Version Number
-        run: echo "Effective version ${{ github.steps.version.outputs.VERSION }}"
-
-      - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.4.0
-        with:
-          version: v0.15.1
-          install: true
-
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: true
+      - name: Set Version
+        id: version
+        run: echo "version=v0.0.0-$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+      - name: Print Version Number
+        run: echo "Effective version ${{ steps.version.outputs.version }}"
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca # v3.9.0
+        with:
+          version: v0.15.1
+          install: true
+
 
       - name: Fetch History
         run: git fetch --prune --unshallow
@@ -54,7 +50,7 @@ jobs:
         run: make vendor vendor.check
 
       - name: Build Images
-        run: make build VERSION=${{ github.steps.version.outputs.VERSION }}
+        run: make build VERSION=${{ steps.version.outputs.version }}
         env:
           # We're using docker buildx, which doesn't actually load the images it
           # builds by default. Specifying --load does so.
@@ -70,7 +66,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish Artifacts to DockerHub
-        run: make publish VERSION=${{ github.steps.version.outputs.VERSION }}
+        run: make publish VERSION=${{ steps.version.outputs.version }}
         env:
           DOCKER_REGISTRY: ${{ vars.REGISTRY_URL }}
           BUILD_REGISTRY: ${{ vars.REGISTRY_URL }}


### PR DESCRIPTION
Since the BTP version of the workflow differed from the initial draft, this PR adjusts the drift and pulls in the new workflow. 