### PR TITLE
fix: Setup controller for providerconfig

### DIFF
--- a/internal/controller/custom_setup.go
+++ b/internal/controller/custom_setup.go
@@ -23,12 +23,15 @@ import (
 	"github.com/SAP/crossplane-provider-cloudfoundry/internal/controller/serviceinstance"
 	"github.com/SAP/crossplane-provider-cloudfoundry/internal/controller/space"
 	"github.com/SAP/crossplane-provider-cloudfoundry/internal/controller/spacequota"
+
+	"github.com/SAP/crossplane-provider-cloudfoundry/internal/controller/providerconfig"
 )
 
 // CustomSetup creates all controllers with the supplied logger and adds them to
 // the supplied manager.
 func CustomSetup(mgr ctrl.Manager, o controller.Options) error {
 	for _, setup := range []func(ctrl.Manager, controller.Options) error{
+		providerconfig.Setup,
 		app.Setup,
 		org.Setup,
 		orgrole.Setup,


### PR DESCRIPTION
This PR fixes #11  by setting up controller for `ProviderConfig` so that it blocks deletion while there is usage. 
<img width="793" alt="image" src="https://github.com/user-attachments/assets/15cb4436-0425-49f8-b30f-18d894ae9fd3" />
