### PR TITLE
fix: ServiceInstance - reference Space by GUID

### DIFF
--- a/apis/resources/v1alpha1/serviceinstance_types.go
+++ b/apis/resources/v1alpha1/serviceinstance_types.go
@@ -292,3 +292,8 @@ func (r *ServiceInstance) GetCloudFoundryName() string {
 	}
 	return *r.Spec.ForProvider.Name
 }
+
+// implement SpaceScoped interface
+func (r *ServiceInstance) GetSpaceRef() *SpaceReference {
+	return &r.Spec.ForProvider.SpaceReference
+}

--- a/internal/clients/space/reference.go
+++ b/internal/clients/space/reference.go
@@ -26,10 +26,7 @@ func ResolveByName(ctx context.Context, clientFn clients.ClientFn, mg resource.M
 	// if external-name is not set, search by Name and Space
 	sr := cr.GetSpaceRef()
 	if sr == nil || sr.SpaceName == nil {
-		if sr.Space != nil { // space GUID is directly set, so we do not need to use names.
-			return nil
-		}
-		return errors.New("Unknown space. Please specify `spaceRef` or `spaceSelector` or using `spaceName` and `orgNames`. ")
+		return nil
 	}
 
 	// spaceName and orgName are set, always retrieve space GUID

--- a/internal/clients/space/reference.go
+++ b/internal/clients/space/reference.go
@@ -23,9 +23,9 @@ func ResolveByName(ctx context.Context, clientFn clients.ClientFn, mg resource.M
 		return errors.New("Cannot resolve space name. The resource does not implement SpaceScoped")
 	}
 
-	// if external-name is not set, search by Name and Space
+	// Check if the space reference is fully populated
 	sr := cr.GetSpaceRef()
-	if sr == nil || sr.SpaceName == nil {
+	if sr == nil || sr.SpaceName == nil || sr.OrgName == nil {
 		return nil
 	}
 


### PR DESCRIPTION
This PR solves #54 
SpaceRef may be empty when external-name is provided.

The functionality is tested manually, and it successfully imports a ServiceInstance if it exists already.
Test object:
```
# Import ServiceInstance with external-name (guid)
apiVersion: cloudfoundry.crossplane.io/v1alpha1
kind: ServiceInstance
metadata:
  name: my-servicenstance-external-name
  namespace: default
  annotations:
    crossplane.io/external-name: d6d339fa-c4f7-4372-8878-4f1ef0266938
spec:
  forProvider:
    type: managed
    name: service-instance
    servicePlan:
      offering: destination
      plan: lite
  managementPolicies:
    - Observe
```
![image](https://github.com/user-attachments/assets/6ed5495d-572d-4d94-9ff4-e0a5ccf4809b)
