### PR TITLE
Add support for for nested JSON/YAML in secret data

### DIFF
--- a/examples/serviceinstance/ups-dynatrace.yaml
+++ b/examples/serviceinstance/ups-dynatrace.yaml
@@ -2,25 +2,33 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: dynatrace-credentials
+  name: my-credentials
   namespace: crossplane-system
 type: Opaque
-stringData:
-  environmentid: environmentid
-  apitoken: apitoken
-  apiurl: apiurl
-  type: dynatrace
+data:
+  login: |
+    {
+      "username": "admin",
+      "password": "secret"
+    }
+  config: |
+    {
+      "database": {
+        "host": "localhost",
+        "port": 5432
+      }
+    }
 
 ---
 # UPS with service credentials from a secret ref
 apiVersion: cloudfoundry.crossplane.io/v1alpha1
 kind: ServiceInstance
 metadata:
-  name: ups-dynatrace
+  name: my-ups
 spec:
   forProvider:
     type: user-provided
-    name: ups-dynatrace
+    name: my-ups
     routeServiceUrl: https://my-route-service.example.com
     syslogDrainUrl: syslog-tls://example.log-aggregator.com:6514
     spaceRef: 
@@ -28,41 +36,6 @@ spec:
       policy:
         resolve: Always
     credentialsSecretRef: 
-        name: dynatrace-credentials
+        name: my-credentials
         namespace: crossplane-system
-        key: "" # to select the whole secret
 
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: dynatrace-json-credentials
-  namespace: crossplane-system
-type: Opaque
-stringData:
-  credentials: |
-    {
-      "environmentid": "environmentid",
-      "apitoken": "apitoken",
-      "apiurl": "apiurl",
-      "type": "dynatrace"
-    }
-
----
-# UPS with service json credentials from a secret key selector
-apiVersion: cloudfoundry.crossplane.io/v1alpha1
-kind: ServiceInstance
-metadata:
-  name: ups-ups-json
-spec:
-  forProvider:
-    type: user-provided
-    name: ups-dynatrace-json
-    spaceRef: 
-      name: my-space
-      policy:
-        resolve: Always
-    credentialsSecretRef: 
-        name: dynatrace-json-credentials
-        namespace: crossplane-system
-        key: credentials


### PR DESCRIPTION

## Description
This PR properly handle nested JSON/YAML structures in referenced Kubernetes secrets, referenced by service instance. Previously, all secret values were converted to strings, which could cause issues when working with structured data.

## Changes
- Modified `ExtractSecret` to attempt parsing each secret value as JSON
- Preserves nested JSON structures when returning all secret data
- Maintains backward compatibility for single key lookups

## Example
Before:
```yaml
# Secret data
login: |
  {
    "username": "admin",
    "password": "secret"
  }
config: |
  {
    "database": {
      "host": "localhost",
      "port": 5432
    }
  }
```
Would return:
```json
{
  "login": "{\"username\":\"admin\",\"password\":\"secret\"}",
  "config": "{\"database\":{\"host\":\"localhost\",\"port\":5432}}"
}
```

After:
```json
{
  "login": {
    "username": "admin",
    "password": "secret"
  },
  "config": {
    "database": {
      "host": "localhost",
      "port": 5432
    }
  }
}
```
<img width="380" alt="image" src="https://github.com/user-attachments/assets/4c31664b-9072-4e5e-9fe8-7f9594dd1d11" />

