### PR TITLE
feat: improve field descriptor documentation

### DIFF
--- a/apis/resources/v1alpha1/app_types.go
+++ b/apis/resources/v1alpha1/app_types.go
@@ -15,10 +15,10 @@ import (
 type AppObservation struct {
 	Resource `json:",inline"`
 
-	// The name of the application.
+	// The `name` of the application.
 	Name string `json:"name,omitempty"`
 
-	// the State of the application.
+	// the `state` of the application.
 	State string `json:"state,omitempty"`
 
 	// The yaml representation of the environment variables.
@@ -26,11 +26,11 @@ type AppObservation struct {
 }
 
 type AppParameters struct {
-	// The name of the application.
+	// The `name` of the application.
 	// +kubebuilder:validation:Required
 	Name string `json:"name,omitempty"`
 
-	// Type of the lifecycle; valid values are `buildpack``, `cnb``, `docker``
+	// Type of the lifecycle; valid values are `buildpack`, `cnb`, `docker`
 	// +kubebuilder:validation:Enum=buildpack;cnb;docker
 	// +kubebuilder:default=buildpack
 	Lifecycle string `json:"lifecycle,omitempty"`

--- a/apis/resources/v1alpha1/domain_types.go
+++ b/apis/resources/v1alpha1/domain_types.go
@@ -15,91 +15,75 @@ type DomainObservation struct {
 	// (String) The GUID of the object.
 	ID *string `json:"id,omitempty"`
 
-	// (to-container) traffic, or external (user-to-container) traffic
-	// Whether the domain is used for internal (container-to-container) traffic, or external (user-to-container) traffic
+	// (Boolean) Whether the domain is used for internal (container-to-container) traffic, or external (user-to-container) traffic.
 	Internal *bool `json:"internal,omitempty"`
 
-	// (String) The name of the domain;must be between 3 ~ 253 characters and follow RFC 1035
-	// The name of the domain;must be between 3 ~ 253 characters and follow [RFC 1035](https://tools.ietf.org/html/rfc1035)
+	// (String) The name of the domain; must be between 3 ~ 253 characters and follow [RFC 1035](https://tools.ietf.org/html/rfc1035).
 	Name *string `json:"name,omitempty"`
 
-	// (String) The organization the domain is scoped to; if set, the domain will only be available in that organization; otherwise, the domain will be globally available
-	// The organization the domain is scoped to; if set, the domain will only be available in that organization; otherwise, the domain will be globally available
+	// (String) The organization the domain is scoped to; if set, the domain will only be available in that organization; otherwise, the domain will be globally available.
 	Org *string `json:"org,omitempty"`
 
-	// (String) The desired router group guid. note: creates a tcp domain; cannot be used when internal is set to true or domain is scoped to an org
-	// The desired router group guid. note: creates a tcp domain; cannot be used when internal is set to true or domain is scoped to an org
+	// (String) The desired router group guid. Note: creates a TCP domain; cannot be used when `internal` is set to true or domain is scoped to an org.
 	RouterGroup *string `json:"routerGroup,omitempty"`
 
-	// (Set of String) Organizations the domain is shared with; if set, the domain will be available in these organizations in addition to the organization the domain is scoped to
-	// Organizations the domain is shared with; if set, the domain will be available in these organizations in addition to the organization the domain is scoped to
+	// (Set of String) Organizations the domain is shared with; if set, the domain will be available in these organizations in addition to the organization the domain is scoped to.
 	// +listType=set
 	SharedOrgs []*string `json:"sharedOrgs,omitempty"`
 
-	// (Set of String) Available protocols for routes using the domain, currently http and tcp
-	// Available protocols for routes using the domain, currently http and tcp
+	// (Set of String) Available protocols for routes using the domain, currently http and tcp.
 	// +listType=set
 	SupportedProtocols []*string `json:"supportedProtocols,omitempty"`
 
-	// (String) The date and time when the resource was created in RFC3339 format.
-	// The date and time when the resource was created in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
+	// (String) The date and time when the resource was created in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
 	CreatedAt *string `json:"createdAt,omitempty"`
 
-	// (String) The date and time when the resource was updated in RFC3339 format.
-	// The date and time when the resource was updated in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
+	// (String) The date and time when the resource was updated in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
 	UpdatedAt *string `json:"updatedAt,omitempty"`
 
-	// (Map of String) The annotations associated with Cloud Foundry resources. Add as described here.
-	// The annotations associated with Cloud Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
+	// (Map of String) The annotations associated with Cloud Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
 	// +mapType=granular
 	Annotations map[string]*string `json:"annotations,omitempty"`
 
-	// (Map of String) The labels associated with Cloud Foundry resources. Add as described here.
-	// The labels associated with Cloud Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
+	// (Map of String) The labels associated with Cloud Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
 	// +mapType=granular
 	Labels map[string]*string `json:"labels,omitempty"`
 }
 
 type DomainParameters struct {
-	// (Deprecated) Domain part of full domain name. If specified the sub_domain argument needs to be provided and the name will be computed. If name is provided, domain and sub_domain will be ignored.
+	// (Deprecated) Domain part of full domain name. If specified, the `subDomain` argument needs to be provided and the `name` will be computed. If `name` is provided, `domain` and `subDomain` will be ignored.
 	// +kubebuilder:deprecated:warning=The domain field is deprecated and will be removed in a future version. Use the name field instead.
 	Domain *string `json:"domain,omitempty" tf:"domain,omitempty"`
 
-	// (Deprecated) Sub-domain part of full domain name. If specified the domain argument needs to be provided and the name will be computed. If name is provided, domain and sub_domain will be ignored.
+	// (Deprecated) Sub-domain part of full domain name. If specified, the `domain` argument needs to be provided and the `name` will be computed. If `name` is provided, `domain` and `subDomain` will be ignored.
 	// +kubebuilder:deprecated:warning=The sub_domain field is deprecated and will be removed in a future version. Use the name field instead.
 	SubDomain *string `json:"subDomain,omitempty" tf:"sub_domain,omitempty"`
 
-	// (String) The name of the domain;must be between 3 ~ 253 characters and follow RFC 1035
-	// The name of the domain;must be between 3 ~ 253 characters and follow [RFC 1035](https://tools.ietf.org/html/rfc1035).
+	// (String) The name of the domain; must be between 3 ~ 253 characters and follow [RFC 1035](https://tools.ietf.org/html/rfc1035).
 	// +kubebuilder:validation:Optional
 	Name string `json:"name,omitempty"`
 
-	// (to-container) traffic, or external (user-to-container) traffic
-	// Whether the domain is used for internal (container-to-container) traffic, or external (user-to-container) traffic
+	// (Boolean) Whether the domain is used for internal (container-to-container) traffic, or external (user-to-container) traffic.
 	// +kubebuilder:validation:Optional
 	Internal *bool `json:"internal,omitempty"`
 
-	// (String) The desired router group guid. note: creates a tcp domain; cannot be used when internal is set to true or domain is scoped to an org
-	// The desired router group guid. note: creates a tcp domain; cannot be used when internal is set to true or domain is scoped to an org
+	// (String) The desired router group guid. Note: creates a TCP domain; cannot be used when `internal` is set to true or domain is scoped to an org.
 	// +kubebuilder:validation:Optional
 	RouterGroup *string `json:"routerGroup,omitempty"`
 
 	OrgReference `json:",inline"`
 
-	// (Set of String) Organizations the domain is shared with; if set, the domain will be available in these organizations in addition to the organization the domain is scoped to
-	// Organizations the domain is shared with; if set, the domain will be available in these organizations in addition to the organization the domain is scoped to
+	// (Set of String) Organizations the domain is shared with; if set, the domain will be available in these organizations in addition to the organization the domain is scoped to.
 	// +kubebuilder:validation:Optional
 	// +listType=set
-	SharedOrgs []*string `json:"sharedOrgs,omitempty"` // TODO: change this to a list of Org references
+	SharedOrgs []*string `json:"sharedOrgs,omitempty"`
 
-	// (Map of String) The annotations associated with Cloud Foundry resources. Add as described here.
-	// The annotations associated with Cloud Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
+	// (Map of String) The annotations associated with Cloud Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
 	// +kubebuilder:validation:Optional
 	// +mapType=granular
 	Annotations map[string]*string `json:"annotations,omitempty" tf:"annotations,omitempty"`
 
-	// (Map of String) The labels associated with Cloud Foundry resources. Add as described here.
-	// The labels associated with Cloud Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
+	// (Map of String) The labels associated with Cloud Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
 	// +kubebuilder:validation:Optional
 	// +mapType=granular
 	Labels map[string]*string `json:"labels,omitempty" tf:"labels,omitempty"`

--- a/apis/resources/v1alpha1/org_types.go
+++ b/apis/resources/v1alpha1/org_types.go
@@ -13,65 +13,50 @@ import (
 	v1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 )
 
-
-
 type OrgObservation struct {
-
-	// (Map of String) The annotations associated with Cloud Foundry resources. Add as described here.
-	// The annotations associated with Cloud Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
+	// (Map of String) The annotations associated with Cloud Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
 	// +mapType=granular
 	Annotations map[string]*string `json:"annotations,omitempty" tf:"annotations,omitempty"`
 
-	// (String) The date and time when the resource was created in RFC3339 format.
-	// The date and time when the resource was created in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
+	// (String) The date and time when the resource was created in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
 	CreatedAt *string `json:"createdAt,omitempty" tf:"created_at,omitempty"`
 
-	// (String) The ID of the Organization
+	// (String) The ID of the Organization.
 	ID *string `json:"id,omitempty" tf:"id,omitempty"`
 
-	// (Map of String) The labels associated with Cloud Foundry resources. Add as described here.
-	// The labels associated with Cloud Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
+	// (Map of String) The labels associated with Cloud Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
 	// +mapType=granular
 	Labels map[string]*string `json:"labels,omitempty" tf:"labels,omitempty"`
 
-	// (String) The name of the Organization in Cloud Foundry
-	// The name of the Organization in Cloud Foundry
+	// (String) The name of the Organization in Cloud Foundry.
 	Name *string `json:"name,omitempty" tf:"name,omitempty"`
 
-	// (String) The ID of quota to be applied to this Org. Default quota is assigned to the org by default.
-	// The ID of quota to be applied to this Org. Default quota is assigned to the org by default.
+	// (String) The ID of quota to be applied to this Organization. Default quota is assigned to the Organization by default.
 	Quota *string `json:"quota,omitempty" tf:"quota,omitempty"`
 
-	// (Boolean) Whether an organization is suspended or not.
-	// Whether an organization is suspended or not.
+	// (Boolean) Whether an Organization is suspended or not.
 	Suspended *bool `json:"suspended,omitempty" tf:"suspended,omitempty"`
 
-	// (String) The date and time when the resource was updated in RFC3339 format.
-	// The date and time when the resource was updated in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
+	// (String) The date and time when the resource was updated in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
 	UpdatedAt *string `json:"updatedAt,omitempty" tf:"updated_at,omitempty"`
 }
 
 type OrgParameters struct {
-
-	// (Map of String) The annotations associated with Cloud Foundry resources. Add as described here.
-	// The annotations associated with Cloud Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
+	// (Map of String) The annotations associated with Cloud Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
 	// +kubebuilder:validation:Optional
 	// +mapType=granular
 	Annotations map[string]*string `json:"annotations,omitempty" tf:"annotations,omitempty"`
 
-	// (Map of String) The labels associated with Cloud Foundry resources. Add as described here.
-	// The labels associated with Cloud Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
+	// (Map of String) The labels associated with Cloud Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
 	// +kubebuilder:validation:Optional
 	// +mapType=granular
 	Labels map[string]*string `json:"labels,omitempty" tf:"labels,omitempty"`
 
-	// (String) The name of the Organization in Cloud Foundry
-	// The name of the Organization in Cloud Foundry
+	// (String) The name of the Organization in Cloud Foundry.
 	// +kubebuilder:validation:Required
 	Name string `json:"name,omitempty" tf:"name,omitempty"`
 
-	// (Boolean) Whether an organization is suspended or not.
-	// Whether an organization is suspended or not.
+	// (Boolean) Whether an Organization is suspended or not.
 	// +kubebuilder:validation:Optional
 	Suspended *bool `json:"suspended,omitempty" tf:"suspended,omitempty"`
 }
@@ -80,7 +65,6 @@ type OrgParameters struct {
 type OrgSpec struct {
 	v1.ResourceSpec `json:",inline"`
 	ForProvider     OrgParameters `json:"forProvider"`
-
 }
 
 // OrgStatus defines the observed state of Org.

--- a/apis/resources/v1alpha1/orgmember_types.go
+++ b/apis/resources/v1alpha1/orgmember_types.go
@@ -7,28 +7,26 @@ import (
 	v1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 )
 
-// OrgMembersParameters encapsulate role assignments to CloudFoundry Organizations
 type OrgMembersParameters struct {
 	MemberList `json:",inline"`
 
 	OrgReference `json:",inline"`
 
-	// Org role type to assign to members; see valid role types https://v3-apidocs.cloudfoundry.org/version/3.127.0/index.html#valid-role-types
+	// (String) Org role type to assign to members; see valid role types https://v3-apidocs.cloudfoundry.org/version/3.127.0/index.html#valid-role-types
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Enum=User;Auditor;Manager;BillingManager;Users;Auditors;Managers;BillingManagers
 	RoleType string `json:"roleType"`
 }
 
-// OrgMembersSpec defines the desired state of OrgMembers
 type OrgMembersSpec struct {
 	v1.ResourceSpec `json:",inline"`
 	ForProvider     OrgMembersParameters `json:"forProvider"`
 }
 
-// OrgMembersStatus defines the observed state of OrgMembers.
 type OrgMembersStatus struct {
 	v1.ResourceStatus `json:",inline"`
-	AtProvider        RoleAssignments `json:"atProvider,omitempty"`
+	// (Attributes) The assigned roles for the organization members.
+	AtProvider RoleAssignments `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -49,7 +47,7 @@ type OrgMembers struct {
 
 // +kubebuilder:object:root=true
 
-// OrgMembersList contains a list of OrgMembers
+// OrgMembersList contains a list of OrgMembers.
 type OrgMembersList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/apis/resources/v1alpha1/orgquota_types.go
+++ b/apis/resources/v1alpha1/orgquota_types.go
@@ -14,193 +14,149 @@ import (
 )
 
 type OrgQuotaInitParameters struct {
-
-	// free service plans. Does not control plan visibility. When false, non-free service plans may be visible in the marketplace but instances can not be provisioned.
-	// Determines whether users can provision instances of non-free service plans. Does not control plan visibility. When false, non-free service plans may be visible in the marketplace but instances can not be provisioned.
+	// (Boolean) Determines whether users can provision instances of non-free service plans. Does not control plan visibility. When false, non-free service plans may be visible in the marketplace but instances cannot be provisioned.
 	AllowPaidServicePlans *bool `json:"allowPaidServicePlans,omitempty" tf:"allow_paid_service_plans,omitempty"`
 
 	// (Number) Maximum memory per application instance.
-	// Maximum memory per application instance.
 	InstanceMemory *float64 `json:"instanceMemory,omitempty" tf:"instance_memory,omitempty"`
 
-	// (String) The name you use to identify the quota or plan in Cloud Foundry
-	// The name you use to identify the quota or plan in Cloud Foundry
+	// (String) The name you use to identify the quota or plan in Cloud Foundry.
 	Name *string `json:"name,omitempty" tf:"name,omitempty"`
 
 	// (Set of String) Set of Org GUIDs to which this org quota would be assigned.
-	// Set of Org GUIDs to which this org quota would be assigned.
 	// +listType=set
 	Orgs []*string `json:"orgs,omitempty" tf:"orgs,omitempty"`
 
 	// (Number) Maximum app instances allowed.
-	// Maximum app instances allowed.
 	TotalAppInstances *float64 `json:"totalAppInstances,omitempty" tf:"total_app_instances,omitempty"`
 
 	// (Number) Maximum log rate allowed for all the started processes and running tasks in bytes/second.
-	// Maximum log rate allowed for all the started processes and running tasks in bytes/second.
 	TotalAppLogRateLimit *float64 `json:"totalAppLogRateLimit,omitempty" tf:"total_app_log_rate_limit,omitempty"`
 
 	// (Number) Maximum tasks allowed per app.
-	// Maximum tasks allowed per app.
 	TotalAppTasks *float64 `json:"totalAppTasks,omitempty" tf:"total_app_tasks,omitempty"`
 
 	// (Number) Maximum memory usage allowed.
-	// Maximum memory usage allowed.
 	TotalMemory *float64 `json:"totalMemory,omitempty" tf:"total_memory,omitempty"`
 
 	// (Number) Maximum number of private domains allowed to be created within the Org.
-	// Maximum number of private domains allowed to be created within the Org.
 	TotalPrivateDomains *float64 `json:"totalPrivateDomains,omitempty" tf:"total_private_domains,omitempty"`
 
 	// (Number) Maximum routes with reserved ports.
-	// Maximum routes with reserved ports.
 	TotalRoutePorts *float64 `json:"totalRoutePorts,omitempty" tf:"total_route_ports,omitempty"`
 
 	// (Number) Maximum routes allowed.
-	// Maximum routes allowed.
 	TotalRoutes *float64 `json:"totalRoutes,omitempty" tf:"total_routes,omitempty"`
 
 	// (Number) Maximum service keys allowed.
-	// Maximum service keys allowed.
 	TotalServiceKeys *float64 `json:"totalServiceKeys,omitempty" tf:"total_service_keys,omitempty"`
 
 	// (Number) Maximum services allowed.
-	// Maximum services allowed.
 	TotalServices *float64 `json:"totalServices,omitempty" tf:"total_services,omitempty"`
 }
 
 type OrgQuotaObservation struct {
-
-	// free service plans. Does not control plan visibility. When false, non-free service plans may be visible in the marketplace but instances can not be provisioned.
-	// Determines whether users can provision instances of non-free service plans. Does not control plan visibility. When false, non-free service plans may be visible in the marketplace but instances can not be provisioned.
+	// (Boolean) Determines whether users can provision instances of non-free service plans. Does not control plan visibility. When false, non-free service plans may be visible in the marketplace but instances cannot be provisioned.
 	AllowPaidServicePlans *bool `json:"allowPaidServicePlans,omitempty" tf:"allow_paid_service_plans,omitempty"`
 
-	// (String) The date and time when the resource was created in RFC3339 format.
-	// The date and time when the resource was created in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
+	// (String) The date and time when the resource was created in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
 	CreatedAt *string `json:"createdAt,omitempty" tf:"created_at,omitempty"`
 
 	// (String) The GUID of the object.
 	ID *string `json:"id,omitempty" tf:"id,omitempty"`
 
 	// (Number) Maximum memory per application instance.
-	// Maximum memory per application instance.
 	InstanceMemory *float64 `json:"instanceMemory,omitempty" tf:"instance_memory,omitempty"`
 
-	// (String) The name you use to identify the quota or plan in Cloud Foundry
-	// The name you use to identify the quota or plan in Cloud Foundry
+	// (String) The name you use to identify the quota or plan in Cloud Foundry.
 	Name *string `json:"name,omitempty" tf:"name,omitempty"`
 
 	// (Set of String) Set of Org GUIDs to which this org quota would be assigned.
-	// Set of Org GUIDs to which this org quota would be assigned.
 	// +listType=set
 	Orgs []*string `json:"orgs,omitempty" tf:"orgs,omitempty"`
 
 	// (Number) Maximum app instances allowed.
-	// Maximum app instances allowed.
 	TotalAppInstances *float64 `json:"totalAppInstances,omitempty" tf:"total_app_instances,omitempty"`
 
 	// (Number) Maximum log rate allowed for all the started processes and running tasks in bytes/second.
-	// Maximum log rate allowed for all the started processes and running tasks in bytes/second.
 	TotalAppLogRateLimit *float64 `json:"totalAppLogRateLimit,omitempty" tf:"total_app_log_rate_limit,omitempty"`
 
 	// (Number) Maximum tasks allowed per app.
-	// Maximum tasks allowed per app.
 	TotalAppTasks *float64 `json:"totalAppTasks,omitempty" tf:"total_app_tasks,omitempty"`
 
 	// (Number) Maximum memory usage allowed.
-	// Maximum memory usage allowed.
 	TotalMemory *float64 `json:"totalMemory,omitempty" tf:"total_memory,omitempty"`
 
 	// (Number) Maximum number of private domains allowed to be created within the Org.
-	// Maximum number of private domains allowed to be created within the Org.
 	TotalPrivateDomains *float64 `json:"totalPrivateDomains,omitempty" tf:"total_private_domains,omitempty"`
 
 	// (Number) Maximum routes with reserved ports.
-	// Maximum routes with reserved ports.
 	TotalRoutePorts *float64 `json:"totalRoutePorts,omitempty" tf:"total_route_ports,omitempty"`
 
 	// (Number) Maximum routes allowed.
-	// Maximum routes allowed.
 	TotalRoutes *float64 `json:"totalRoutes,omitempty" tf:"total_routes,omitempty"`
 
 	// (Number) Maximum service keys allowed.
-	// Maximum service keys allowed.
 	TotalServiceKeys *float64 `json:"totalServiceKeys,omitempty" tf:"total_service_keys,omitempty"`
 
 	// (Number) Maximum services allowed.
-	// Maximum services allowed.
 	TotalServices *float64 `json:"totalServices,omitempty" tf:"total_services,omitempty"`
 
-	// (String) The date and time when the resource was updated in RFC3339 format.
-	// The date and time when the resource was updated in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
+	// (String) The date and time when the resource was updated in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
 	UpdatedAt *string `json:"updatedAt,omitempty" tf:"updated_at,omitempty"`
 }
 
 type OrgQuotaParameters struct {
-
-	// free service plans. Does not control plan visibility. When false, non-free service plans may be visible in the marketplace but instances can not be provisioned.
-	// Determines whether users can provision instances of non-free service plans. Does not control plan visibility. When false, non-free service plans may be visible in the marketplace but instances can not be provisioned.
+	// (Boolean) Determines whether users can provision instances of non-free service plans. Does not control plan visibility. When false, non-free service plans may be visible in the marketplace but instances cannot be provisioned.
 	// +kubebuilder:validation:Optional
 	AllowPaidServicePlans *bool `json:"allowPaidServicePlans,omitempty" tf:"allow_paid_service_plans,omitempty"`
 
 	// (Number) Maximum memory per application instance.
-	// Maximum memory per application instance.
 	// +kubebuilder:validation:Optional
 	InstanceMemory *float64 `json:"instanceMemory,omitempty" tf:"instance_memory,omitempty"`
 
-	// (String) The name you use to identify the quota or plan in Cloud Foundry
-	// The name you use to identify the quota or plan in Cloud Foundry
+	// (String) The name you use to identify the quota or plan in Cloud Foundry.
 	// +kubebuilder:validation:Optional
 	Name *string `json:"name,omitempty" tf:"name,omitempty"`
 
 	// (Set of String) Set of Org GUIDs to which this org quota would be assigned.
-	// Set of Org GUIDs to which this org quota would be assigned.
 	// +kubebuilder:validation:Optional
 	// +listType=set
 	Orgs []*string `json:"orgs,omitempty" tf:"orgs,omitempty"`
 
 	// (Number) Maximum app instances allowed.
-	// Maximum app instances allowed.
 	// +kubebuilder:validation:Optional
 	TotalAppInstances *float64 `json:"totalAppInstances,omitempty" tf:"total_app_instances,omitempty"`
 
 	// (Number) Maximum log rate allowed for all the started processes and running tasks in bytes/second.
-	// Maximum log rate allowed for all the started processes and running tasks in bytes/second.
 	// +kubebuilder:validation:Optional
 	TotalAppLogRateLimit *float64 `json:"totalAppLogRateLimit,omitempty" tf:"total_app_log_rate_limit,omitempty"`
 
 	// (Number) Maximum tasks allowed per app.
-	// Maximum tasks allowed per app.
 	// +kubebuilder:validation:Optional
 	TotalAppTasks *float64 `json:"totalAppTasks,omitempty" tf:"total_app_tasks,omitempty"`
 
 	// (Number) Maximum memory usage allowed.
-	// Maximum memory usage allowed.
 	// +kubebuilder:validation:Optional
 	TotalMemory *float64 `json:"totalMemory,omitempty" tf:"total_memory,omitempty"`
 
 	// (Number) Maximum number of private domains allowed to be created within the Org.
-	// Maximum number of private domains allowed to be created within the Org.
 	// +kubebuilder:validation:Optional
 	TotalPrivateDomains *float64 `json:"totalPrivateDomains,omitempty" tf:"total_private_domains,omitempty"`
 
 	// (Number) Maximum routes with reserved ports.
-	// Maximum routes with reserved ports.
 	// +kubebuilder:validation:Optional
 	TotalRoutePorts *float64 `json:"totalRoutePorts,omitempty" tf:"total_route_ports,omitempty"`
 
 	// (Number) Maximum routes allowed.
-	// Maximum routes allowed.
 	// +kubebuilder:validation:Optional
 	TotalRoutes *float64 `json:"totalRoutes,omitempty" tf:"total_routes,omitempty"`
 
 	// (Number) Maximum service keys allowed.
-	// Maximum service keys allowed.
 	// +kubebuilder:validation:Optional
 	TotalServiceKeys *float64 `json:"totalServiceKeys,omitempty" tf:"total_service_keys,omitempty"`
 
 	// (Number) Maximum services allowed.
-	// Maximum services allowed.
 	// +kubebuilder:validation:Optional
 	TotalServices *float64 `json:"totalServices,omitempty" tf:"total_services,omitempty"`
 }

--- a/apis/resources/v1alpha1/orgrole_types.go
+++ b/apis/resources/v1alpha1/orgrole_types.go
@@ -14,62 +14,49 @@ import (
 )
 
 type OrgRoleObservation struct {
-
-	// (String) The date and time when the resource was created in RFC3339 format.
-	// The date and time when the resource was created in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
+	// (String) The date and time when the resource was created in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
 	CreatedAt *string `json:"createdAt,omitempty" tf:"created_at,omitempty"`
 
 	// (String) The GUID of the object.
 	ID *string `json:"id,omitempty" tf:"id,omitempty"`
 
-	// (String) The identity provider for the UAA user
-	// The identity provider for the UAA user
+	// (String) The identity provider for the UAA user.
 	Origin *string `json:"origin,omitempty" tf:"origin,omitempty"`
 
-	// (String) OrgRole type; see Valid role types
-	// OrgRole type; see [Valid role types](https://v3-apidocs.cloudfoundry.org/version/3.154.0/index.html#valid-role-types)
+	// (String) The org role type; see [Valid role types](https://v3-apidocs.cloudfoundry.org/version/3.154.0/index.html#valid-role-types).
 	Type *string `json:"type,omitempty" tf:"type,omitempty"`
 
-	// (String) The date and time when the resource was updated in RFC3339 format.
-	// The date and time when the resource was updated in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
+	// (String) The date and time when the resource was updated in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
 	UpdatedAt *string `json:"updatedAt,omitempty" tf:"updated_at,omitempty"`
 
-	// (String) The guid of the cloudfoundry user to assign the role with
-	// The guid of the cloudfoundry user to assign the role with
+	// (String) The GUID of the Cloud Foundry user to assign the role to.
 	User *string `json:"user,omitempty" tf:"user,omitempty"`
 
-	// (String) The username of the cloudfoundry user to assign the role with
-	// The username of the cloudfoundry user to assign the role with
+	// (String) The username of the Cloud Foundry user to assign the role to.
 	Username *string `json:"username,omitempty" tf:"username,omitempty"`
 }
 
 type OrgRoleParameters struct {
-
 	OrgReference `json:",inline"`
 
-	// (String) OrgRole type; see Valid role types
-	// OrgRole type; see [Valid role types](https://v3-apidocs.cloudfoundry.org/version/3.154.0/index.html#valid-role-types)
+	// (String) The org role type; see [Valid role types](https://v3-apidocs.cloudfoundry.org/version/3.154.0/index.html#valid-role-types).
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Enum=User;Auditor;Manager;BillingManager;Users;Auditors;Managers;BillingManagers
 	Type string `json:"type,omitempty" tf:"type,omitempty"`
 
-	// (String) The identity provider for the UAA user
-	// The identity provider for the UAA user
+	// (String) The identity provider for the UAA user.
 	// +kubebuilder:validation:Optional
 	Origin *string `json:"origin,omitempty" tf:"origin,omitempty"`
 
-	// (String) The username of the cloudfoundry user to assign the role with
-	// The username of the cloudfoundry user to assign the role with
+	// (String) The username of the Cloud Foundry user to assign the role to.
 	// +kubebuilder:validation:Required
 	Username string `json:"username,omitempty" tf:"username,omitempty"`
-
 }
 
 // OrgRoleSpec defines the desired state of OrgRole
 type OrgRoleSpec struct {
 	v1.ResourceSpec `json:",inline"`
 	ForProvider     OrgRoleParameters `json:"forProvider"`
-
 }
 
 // OrgRoleStatus defines the observed state of OrgRole.
@@ -91,8 +78,8 @@ type OrgRoleStatus struct {
 type OrgRole struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec   OrgRoleSpec   `json:"spec"`
-	Status OrgRoleStatus `json:"status,omitempty"`
+	Spec              OrgRoleSpec   `json:"spec"`
+	Status            OrgRoleStatus `json:"status,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/apis/resources/v1alpha1/references.go
+++ b/apis/resources/v1alpha1/references.go
@@ -4,66 +4,66 @@ import (
 	v1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 )
 
-// SpaceReference defines a reference to a Cloud Foundry space
+// SpaceReference defines a reference to a Cloud Foundry space.
 type SpaceReference struct {
-	// The `guid` of the Cloud Foundry space. This field is typically populated using references specified in `spaceRef`, `spaceSelector`, or `spaceName`.
+	// (String) The GUID of the Cloud Foundry space. This field is typically populated using references specified in `spaceRef`, `spaceSelector`, or `spaceName`.
 	// +crossplane:generate:reference:type=Space
 	// +crossplane:generate:reference:extractor=github.com/SAP/crossplane-provider-cloudfoundry/apis/resources.ExternalID()
 	Space *string `json:"space,omitempty"`
 
-	// The name of the Cloud Foundry space to lookup the `guid` of the Space. Use `spaceName` only when the reference Space is not managed by Crossplane.
+	// (String) The name of the Cloud Foundry space to lookup the GUID of the space. Use `spaceName` only when the referenced space is not managed by Crossplane.
 	// +kubebuilder:validation:Optional
 	SpaceName *string `json:"spaceName,omitempty"`
 
-	// The name of the Cloud Foundry organization containing the space.
+	// (String) The name of the Cloud Foundry organization containing the space.
 	// +kubebuilder:validation:Optional
 	OrgName *string `json:"orgName,omitempty"`
 
-	// Reference to a `Space` CR to lookup the `guid` of the Cloud Foundry space. Preferred if the reference space is managed by Crossplane.
+	// (Attributes) Reference to a `Space` CR to lookup the GUID of the Cloud Foundry space. Preferred if the referenced space is managed by Crossplane.
 	// +kubebuilder:validation:Optional
 	SpaceRef *v1.Reference `json:"spaceRef,omitempty"`
 
-	// Selector for a `Space` CR to lookup the `guid` of the Cloud Foundry space. Preferred if the reference space is managed by Crossplane.
+	// (Attributes) Selector for a `Space` CR to lookup the GUID of the Cloud Foundry space. Preferred if the referenced space is managed by Crossplane.
 	// +kubebuilder:validation:Optional
 	SpaceSelector *v1.Selector `json:"spaceSelector,omitempty"`
 }
 
-// OrgReference is a struct that represents the reference to a Organization CR.
+// OrgReference is a struct that represents the reference to an Organization CR.
 type OrgReference struct {
-	// (String) The guid of the organization
+	// (String) The GUID of the organization.
 	// +crossplane:generate:reference:type=Organization
 	// +crossplane:generate:reference:extractor=github.com/SAP/crossplane-provider-cloudfoundry/apis/resources.ExternalID()
 	Org *string `json:"org,omitempty"`
 
-	// The name of the Cloud Foundry organization containing the space.
+	// (String) The name of the Cloud Foundry organization containing the space.
 	// +kubebuilder:validation:Optional
 	OrgName *string `json:"orgName,omitempty"`
 
-	// Reference to an `Org` CR to retrieve the external GUID of the organization.
+	// (Attributes) Reference to an `Org` CR to retrieve the external GUID of the organization.
 	// +kubebuilder:validation:Optional
 	OrgRef *v1.Reference `json:"orgRef,omitempty"`
 
-	// Selector to an `Org` CR to retrieve the external GUID of the Organization.
+	// (Attributes) Selector to an `Org` CR to retrieve the external GUID of the organization.
 	// +kubebuilder:validation:Optional
 	OrgSelector *v1.Selector `json:"orgSelector,omitempty"`
 }
 
-// DomainReference defines a reference to a Cloud Foundry Domain
+// DomainReference defines a reference to a Cloud Foundry Domain.
 type DomainReference struct {
-	// The `guid` of the Cloud Foundry domain. This field is typically populated using references specified in `domainRef`, `domainSelector`, or `domainName`.
+	// (String) The GUID of the Cloud Foundry domain. This field is typically populated using references specified in `domainRef`, `domainSelector`, or `domainName`.
 	// +crossplane:generate:reference:type=Domain
 	// +crossplane:generate:reference:extractor=github.com/SAP/crossplane-provider-cloudfoundry/apis/resources.ExternalID()
 	Domain *string `json:"domain,omitempty"`
 
-	// The name of the Cloud Foundry domain to lookup the `guid` of the Domain. Use `domainName` only when the referenced Domain is not managed by Crossplane.
+	// (String) The name of the Cloud Foundry domain to lookup the GUID of the domain. Use `domainName` only when the referenced domain is not managed by Crossplane.
 	// +kubebuilder:validation:Optional
 	DomainName *string `json:"domainName,omitempty"`
 
-	// Reference to a `Domain` CR to lookup the `guid` of the Cloud Foundry domain. Preferred if the reference domain is managed by Crossplane.
+	// (Attributes) Reference to a `domain` CR to lookup the GUID of the Cloud Foundry domain. Preferred if the referenced domain is managed by Crossplane.
 	// +kubebuilder:validation:Optional
 	DomainRef *v1.Reference `json:"domainRef,omitempty"`
 
-	// Selector for a `Domain` CR to lookup the `guid` of the Cloud Foundry domain. Preferred if the reference domain is managed by Crossplane.
+	// (Attributes) Selector for a `domain` CR to lookup the GUID of the Cloud Foundry domain. Preferred if the referenced domain is managed by Crossplane.
 	// +kubebuilder:validation:Optional
 	DomainSelector *v1.Selector `json:"domainSelector,omitempty"`
 }

--- a/apis/resources/v1alpha1/resource.go
+++ b/apis/resources/v1alpha1/resource.go
@@ -1,22 +1,22 @@
 package v1alpha1
 
-// Resource is a generic struct that represents a Cloud Foundry resource.
+// Resource represents a Cloud Foundry resource.
 type Resource struct {
-	// The GUID of the Cloud Foundry resource
+	// (String) The GUID of the Cloud Foundry resource.
 	GUID string `json:"guid,omitempty"`
 
-	// The date and time when the resource was created in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
+	// (String) The date and time when the resource was created in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
 	CreatedAt *string `json:"createdAt,omitempty"`
 
-	// The date and time when the resource was updated in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
+	// (String) The date and time when the resource was updated in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
 	UpdatedAt *string `json:"updatedAt,omitempty"`
 }
 
-// ResourceMetadata is a struct that represents the metadata associated with Cloud Foundry resources.
+// ResourceMetadata represents the metadata associated with a Cloud Foundry resource.
 type ResourceMetadata struct {
-	// The annotations associated with Cloud Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
+	// (Map of String) The annotations associated with the resource. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
 	Annotations map[string]*string `json:"annotations,omitempty"`
 
-	// The labels associated with Cloud Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
+	// (Map of String) The labels associated with the resource. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
 	Labels map[string]*string `json:"labels,omitempty"`
 }

--- a/apis/resources/v1alpha1/role_types.go
+++ b/apis/resources/v1alpha1/role_types.go
@@ -32,12 +32,12 @@ const (
 	SpaceDevelopers    = "Developers"
 )
 
-// Member identifies a user by name and origin
+// Member identifies a user by name and origin.
 type Member struct {
-	// Username at the identity provider
+	// (String) Username at the identity provider.
 	Username string `json:"username"`
+	// (String) Origin selects the identity provider. Defaults to "sap.ids".
 	// +kubebuilder:default=sap.ids
-	// Origin picks the IDP
 	Origin string `json:"origin,omitempty"`
 }
 
@@ -65,20 +65,18 @@ func (u *Member) Equal(other interface{}) bool {
 	return u.Username == uu.Username && u.Origin == uu.Origin
 }
 
-// RoleAssignments maps members to roles
+// RoleAssignments maps members to roles.
 type RoleAssignments struct {
-	// `AssignedRoles` maps member to GUIDs of the assigned Role objects.
+	// (Map of String) `assignedRoles` maps a member to the GUID of the assigned Role object.
 	AssignedRoles map[string]string `json:"assignedRoles,omitempty"`
 }
 
-// MemberList includes a list of members
-// and enables to set an enforcement policy which helps to work with different sources of members,
-// maybe not just this reousrce
+// MemberList includes a list of members and an enforcement policy for role assignment.
 type MemberList struct {
-	// List of members (usernames) to assign as org members with the specified role type. Defaults to empty list.
+	// (List of Attributes) List of members (usernames) to assign as org members with the specified role type. Defaults to empty list.
 	Members []*Member `json:"members"`
 
-	// Set to `Lax` to enforce that the role is assigned to AT LEAST those members as defined in this CR. Set to `Strict` to enforce that the role is assigned to EXACT those members as defined in CR and any other members will be removed. Defaults to `Lax`.
+	// (String) Set to `Lax` to enforce that the role is assigned to AT LEAST those members as defined in this CR. Set to `Strict` to enforce that the role is assigned to EXACTLY those members as defined in this CR and any other members will be removed. Defaults to `Lax`.
 	// +optional
 	// +kubebuilder:default=Lax
 	// +kubebuilder:validation:Enum=Lax;Strict

--- a/apis/resources/v1alpha1/route_types.go
+++ b/apis/resources/v1alpha1/route_types.go
@@ -7,91 +7,88 @@ import (
 	v1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 )
 
-// RouteObservation observations for routes
 type RouteObservation struct {
 	Resource `json:",inline"`
 
-	// Protocol of the route
+	// (String) The protocol of the route.
 	// +kubebuilder:validation:Optional
 	Protocol *string `json:"protocol,omitempty"`
 
-	// The host name of the route
+	// (String) The host name of the route.
 	// +kubebuilder:validation:Optional
 	Host *string `json:"host,omitempty"`
 
-	// The path of the route
+	// (String) The path of the route.
 	// +kubebuilder:validation:Optional
 	Path *string `json:"path,omitempty"`
 
-	// The URL of the route
+	// (String) The URL of the route.
 	// +kubebuilder:validation:Optional
 	URL *string `json:"url,omitempty"`
 
-	// The route options
+	// (Attributes) The route options.
 	// +kubebuilder:validation:Optional
 	Options *RouteOptions `json:"options,omitempty"`
 
-	// One or more route mapping(s) that will map this route to application(s). Can be repeated multiple times to load balance route traffic among multiple applications.
+	// (List of Attributes) One or more route mappings that map this route to applications. Can be repeated to load balance route traffic among multiple applications.
 	// +kubebuilder:validation:Optional
 	Destinations []RouteDestination `json:"destinations,omitempty"`
 }
 
-// RouteParameters parameters for Routes
 type RouteParameters struct {
 	SpaceReference `json:",inline"`
 
 	DomainReference `json:",inline"`
 
-	// The application's host name. This is required for shared domains.
+	// (String) The application's host name. Required for shared domains.
 	// +kubebuilder:validation:Optional
 	Host *string `json:"host,omitempty"`
 
-	// A path for an HTTP route.
+	// (String) A path for an HTTP route.
 	// +kubebuilder:validation:Optional
 	Path *string `json:"path,omitempty"`
 
-	// The port to associate with the route for a TCP route. Conflicts with random_port.
+	// (Integer) The port to associate with the route for a TCP route. Conflicts with `random_port`.
 	// +kubebuilder:validation:Optional
 	Port *int `json:"port,omitempty"`
 
-	// The route options
+	// (Attributes) The route options.
 	// +kubebuilder:validation:Optional
 	Options *RouteOptions `json:"options,omitempty"`
 }
 
-// RouteOptions parameters for domain.
 type RouteOptions struct {
-	// The load-balancer associated with this route. Valid values are ‘round-robin’ and ‘least-connections’
+	// (String) The load balancer associated with this route. Valid values are `round-robin` and `least-connections`.
 	// +kubebuilder:validation:Optional
 	LoadBalancing string `json:"loadbalancing,omitempty"`
 }
 
-// RouteDestination describes a route destinations
 type RouteDestination struct {
-	// The destination GUID
+	// (String) The destination GUID.
 	GUID string `json:"guid,omitempty"`
 
-	// The ID of the application to map this route to.
+	// (Attributes) The application to map this route to.
 	// +kubebuilder:validation:Required
 	App *RouteDestinationApp `json:"app,omitempty"`
 
-	// The port to associate with the route for a TCP route. Conflicts with random_port.
+	// (Integer) The port to associate with the route for a TCP route. Conflicts with `random_port`.
 	// +kubebuilder:validation:Optional
 	Port *int `json:"port,omitempty"`
 }
 
-// DestinationApp describes a destination application
 type RouteDestinationApp struct {
+	// (String) The application GUID.
 	GUID string `json:"guid,omitempty"`
 
-	// The process type of the destination.
+	// (String) The process type of the destination.
 	// +kubebuilder:validation:Optional
 	Process *string `json:"process,omitempty"`
 
-	// Port on the destination application
+	// (Integer) Port on the destination application.
 	// +kubebuilder:validation:Optional
 	Port *int `json:"port,omitempty"`
 
+	// (String) The protocol for the destination application.
 	Protocol *string `json:"protocol,omitempty"`
 }
 

--- a/apis/resources/v1alpha1/servicecredentialbinding_types.go
+++ b/apis/resources/v1alpha1/servicecredentialbinding_types.go
@@ -11,70 +11,67 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-// ServiceCredentialBindingObservation defines the observed state of ServiceCredentialBinding
 type ServiceCredentialBindingObservation struct {
 	Resource `json:",inline"`
-	// LastOperation describes the last operation performed on the service credential binding.
+	// (Attributes) The details of the last operation performed on the service credential binding.
 	LastOperation *LastOperation `json:"lastOperation,omitempty"`
 }
 
-// ServiceCredentialBindingParameters define the desired state of the forProvider field of ServiceCredentialBinding
 type ServiceCredentialBindingParameters struct {
-	// The type of the Service Key in Cloud Foundry. Either "key" or "app".
+	// (String) The type of the service credential binding in Cloud Foundry. Either "key" or "app".
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Enum=key;app
 	// +kubebuilder:default=key
 	Type string `json:"type,omitempty"`
 
-	// The name of the Service Key in Cloud Foundry. Required if Type is "key".
+	// (String) The name of the service credential binding in Cloud Foundry. Required if `type` is "key".
 	// +kubebuilder:validation:Optional
 	Name *string `json:"name,omitempty"`
 
-	// The ID of the Service Instance the key should be associated with.
+	// (String) The ID of the service instance the binding should be associated with.
 	// +crossplane:generate:reference:type=github.com/SAP/crossplane-provider-cloudfoundry/apis/resources/v1alpha1.ServiceInstance
 	// +kubebuilder:validation:Optional
 	ServiceInstance *string `json:"serviceInstance,omitempty"`
 
-	// Reference to a ManagedServiceInstance to populate serviceInstance.
+	// (Attributes) Reference to a managed service instance to populate `serviceInstance`.
 	// +kubebuilder:validation:Optional
 	ServiceInstanceRef *v1.Reference `json:"serviceInstanceRef,omitempty"`
 
-	// Selector for a ManagedServiceInstance to populate serviceInstance.
+	// (Attributes) Selector for a managed service instance to populate `serviceInstance`.
 	// +kubebuilder:validation:Optional
 	ServiceInstanceSelector *v1.Selector `json:"serviceInstanceSelector,omitempty"`
 
-	// The ID of an App  that should be bound to. Required if Type is "app".
+	// (String) The ID of an app that should be bound to. Required if `type` is "app".
 	// +crossplane:generate:reference:type=App
 	// +kubebuilder:validation:Optional
 	App *string `json:"app,omitempty"`
 
-	// Reference to an App CR to populate app.
+	// (Attributes) Reference to an app CR to populate `app`.
 	// +kubebuilder:validation:Optional
 	AppRef *v1.Reference `json:"appRef,omitempty"`
 
-	// Selector for an App CR to populate app.
+	// (Attributes) Selector for an app CR to populate `app`.
 	// +kubebuilder:validation:Optional
 	AppSelector *v1.Selector `json:"appSelector,omitempty"`
 
-	// An optional JSON object to pass parameters to the service broker .
+	// (Attributes) An optional JSON object to pass `parameters` to the service broker.
 	// +kubebuilder:validation:Optional
 	Parameters *runtime.RawExtension `json:"parameters,omitempty"`
 
-	// Use a reference to a secret to pass parameters to the service broker. Ignored if parameters is set.
+	// (Attributes) Use a reference to a secret to pass `parameters` to the service broker. Ignored if `parameters` is set.
 	// +kubebuilder:validation:Optional
 	ParametersSecretRef *v1.SecretReference `json:"paramsSecretRef,omitempty"`
 
-	// (Deprecated) True to write connectionDetails as single key-value in a secret rather than a map. The key is the metadata.name of the service credential binding CR itself. This is deprecated in favor of the spec.connectionDetailsAsJSON field.
+	// (Boolean, Deprecated) True to write `connectionDetails` as a single key-value in a secret rather than a map. The key is the metadata.name of the service credential binding CR itself. This is deprecated in favor of the `spec.connectionDetailsAsJSON` field.
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=false
 	ConnectionDetailsAsJSON bool `json:"connectionDetailsAsJSON,omitempty"`
 }
 
-// ServiceCredentialBindingSpec defines the desired state of ServiceCredentialBinding
 type ServiceCredentialBindingSpec struct {
 	v1.ResourceSpec `json:",inline"`
 
-	// True to write connectionDetails as single key-value in a secret rather than a map. The key is the metadata.name of the service credential binding CR itself.
+	// (Boolean) True to write `connectionDetails` as a single key-value in a secret rather than a map. The key is the metadata.name of the service credential binding CR itself.
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=false
 	ConnectionDetailsAsJSON bool `json:"connectionDetailsAsJSON,omitempty"`
@@ -82,7 +79,6 @@ type ServiceCredentialBindingSpec struct {
 	ForProvider ServiceCredentialBindingParameters `json:"forProvider"`
 }
 
-// ServiceCredentialBindingStatus defines the observed state of ServiceCredentialBinding.
 type ServiceCredentialBindingStatus struct {
 	v1.ResourceStatus `json:",inline"`
 	AtProvider        ServiceCredentialBindingObservation `json:"atProvider,omitempty"`

--- a/apis/resources/v1alpha1/serviceinstance_types.go
+++ b/apis/resources/v1alpha1/serviceinstance_types.go
@@ -8,8 +8,8 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	v1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 )
@@ -19,213 +19,192 @@ import (
 type ServiceInstanceType string
 
 const (
-	// ManagedService manes the external resource is a managed service instance.
+	// ManagedService means the external resource is a managed service instance.
 	ManagedService ServiceInstanceType = "managed"
 
 	// UserProvidedService means the external resource is a user-provided service instance.
 	UserProvidedService ServiceInstanceType = "user-provided"
 )
 
-
-// ServiceInstanceParameters define the desired state of a Cloud Foundry service instance.
 type ServiceInstanceParameters struct {
-	// The name of the service instance
+	// (String) The name of the service instance
 	// +kubebuilder:validation:Required
 	Name *string `json:"name,omitempty" tf:"name,omitempty"`
 
-	// Type of the service instance. Either managed or user-provided. Default is managed.
+	// (String) Type of the service instance. Either managed or user-provided. Default is managed.
 	// +required
 	// +kubebuilder:default=managed
 	Type ServiceInstanceType `json:"type"`
 
+	// (Attributes) Reference to the Cloud Foundry space where the service instance will be created.
 	SpaceReference `json:",inline"`
 
-	// Fields relevant  for managed service instances
+	// (Attributes) Fields relevant for managed service instances. Only used when `type` is `managed`.
 	Managed `json:",inline"`
 
-	// Fields relevant only for user-provided service instances
+	// (Attributes) Fields relevant only for user-provided service instances. Only used when `type` is `user-provided`.
 	UserProvided `json:",inline"`
 
-	// Timeouts for the service instance operations
+	// (Attributes) Timeouts for the service instance operations.
 	// +kubebuilder:validation:Optional
 	Timeouts TimeoutsParameters `json:"timeouts,omitempty" tf:"timeouts,omitempty"`
 
-	// List of tags used by apps to identify service instances. They are shown in the app VCAP_SERVICES env.
+	// (List of String) List of tags used by apps to identify service instances. They are shown in the app VCAP_SERVICES env.
 	// +kubebuilder:validation:Optional
 	Tags []*string `json:"tags,omitempty" tf:"tags,omitempty"`
 
-	// The annotations associated with Cloud Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
+	// (Map of String) The annotations associated with Cloud Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
 	// +kubebuilder:validation:Optional
 	// +mapType=granular
 	Annotations map[string]*string `json:"annotations,omitempty" tf:"annotations,omitempty"`
 }
 
-
-// Managed defines parameters only valid for a managed service instance
+// Managed configuration for a managed service instance. Only used when `type` is `managed`.
 type Managed struct {
-	// (String) The ID of the service plan from which to create the service instance
-	// The ID of the service plan from which to create the service instance
+
+	// (Attributes) Reference to the service plan for the managed service instance.
 	// +kubebuilder:validation:Optional
 	ServicePlan *ServicePlanParameters `json:"servicePlan,omitempty"`
 
-	// Configuration parameters for the managed service instance, supplied as K8S runtime.RawExtension object
-	//
-	// The `parameters` field is NOT secret or secured in any way and should
-	// NEVER be used to hold sensitive information. To set parameters that
-	// contain secret information, you should ALWAYS store that information
-	// in a Secret and use the `paramsSecretRef` field.
+	// (Attributes) Configuration parameters for the managed service instance, supplied as a K8S runtime.RawExtension object.
+	// The `parameters` field is NOT secret or secured in any way and should NEVER be used to hold sensitive information.
+	// To set parameters that contain secret information, you should ALWAYS store that information in a Secret and use the `paramsSecretRef` field.
 	// +kubebuilder:pruning:PreserveUnknownFields
 	Parameters *runtime.RawExtension `json:"parameters,omitempty"`
 
-
-	// Same as `parameters`, supplied as arbitrary JSON string. Ignored if `parameters` is set.
+	// (String) Same as `parameters`, supplied as arbitrary JSON string. Ignored if `parameters` is set.
 	// +optional
 	JSONParams *string `json:"jsonParams,omitempty"`
 
-	// Same as `parameters`, supplied as a Secret reference. Ignored if `parameters` or `jsonParams` is set.
+	// (Attributes) Same as `parameters`, supplied as a Secret reference. Ignored if `parameters` or `jsonParams` is set.
 	// +kubebuilder:validation:Optional
 	ParametersSecretRef *v1.SecretReference `json:"paramsSecretRef,omitempty" tf:"-"`
 
-
-	// MaintenanceInfo describes the version of the service instance
+	// (Attributes) Information about the version of this service instance; only shown when `type` is `managed`.
 	MaintenanceInfo MaintenanceInfo `json:"maintenanceInfo,omitempty"`
-
 }
 
-// UserProvided defines parameters only valid for a user-provided service instance
+// UserProvided configuration for a user-provided service instance. Only used when `type` is `user-provided`.
 type UserProvided struct {
-	// Arbitrary credentials as K8S runtime.RawExtension object, delivered to applications via VCAP_SERVICES environment variables.Applicable for user-provided service instance type.
-	//
-	// The Credentials field is NOT secret or secured in any way and should
-	// NEVER be used to hold sensitive information. To set parameters that
-	// contain secret information, you should ALWAYS store that information
-	// in a Secret and use the `credentialsSecretRef` field.
+	// (Attributes) Arbitrary credentials as K8S runtime.RawExtension object, delivered to applications via VCAP_SERVICES environment variables.
+	// The `credentials` field is NOT secret or secured in any way and should NEVER be used to hold sensitive information.
+	// To set parameters that contain secret information, you should ALWAYS store that information in a Secret and use the `credentialsSecretRef` field.
 	// +kubebuilder:pruning:PreserveUnknownFields
 	Credentials *runtime.RawExtension `json:"credentials,omitempty"`
 
-	// Same as `credentials`, supplied as arbitrary JSON string. Ignored if `credentials` is set.
+	// (String) Same as `credentials`, supplied as arbitrary JSON string. Ignored if `credentials` is set.
 	// +optional
 	JSONCredentials *string `json:"jsonCredentials,omitempty"`
 
-	// Same as `Credentials`, supplied as a Secret reference. Ignored if `credentials` or `jsonCredentials` is set.
+	// (Attributes) Same as `credentials`, supplied as a Secret reference. Ignored if `credentials` or `jsonCredentials` is set.
 	// +kubebuilder:validation:Optional
 	CredentialsSecretRef *v1.SecretReference `json:"credentialsSecretRef,omitempty"`
 
-	// URL to which requests for bound routes will be forwarded; only shown when type is user-provided.
+	// (String) URL to which requests for bound routes will be forwarded; only shown when `type` is `user-provided`.
 	// +kubebuilder:validation:Optional
 	RouteServiceURL string `json:"routeServiceUrl,omitempty"`
 
-	// URL to which logs for bound applications will be streamed; only shown when type is user-provided.
+	// (String) URL to which logs for bound applications will be streamed; only shown when `type` is `user-provided`.
 	// +kubebuilder:validation:Optional
 	SyslogDrainURL string `json:"syslogDrainUrl,omitempty"`
-
 }
 
-// ServiceInstanceObservation records the observed state of a Cloud Foundry service instance.
 type ServiceInstanceObservation struct {
-	// The GUID of the service instance
+	// (String) The GUID of the service instance.
 	ID *string `json:"id,omitempty"`
 
-	// The name of the service instance
+	// (String) The name of the service instance.
 	Name *string `json:"name,omitempty" tf:"name,omitempty"`
 
-	// The GUID of the space in which the service instance was created
+	// (String) The GUID of the space in which the service instance was created.
 	Space *string `json:"space,omitempty"`
 
-	// The GUID of the Service Plan for a managed service
+	// (String) The GUID of the service plan for a managed service instance.
 	ServicePlan *string `json:"servicePlan,omitempty"`
 
-	// The applied parameters of the managed service instance (TO BE IMPLEMENTED)
+	// (Attributes) The applied parameters of the managed service instance (TO BE IMPLEMENTED).
 	Parameters runtime.RawExtension `json:"parameters,omitempty"`
 
-	// The applied parameters of the managed service instance
+	// (String) The applied credentials of the managed service instance.
 	Credentials []byte `json:"credentials,omitempty"`
 
-	// The job GUID of the last async operation performed on the resource
+	// (String) The job GUID of the last async operation performed on the resource.
 	LastAsyncJob *string `json:"lastAsyncJob,omitempty"`
 
-
-	// (Map of String) The annotations associated with Cloud Foundry resources. Add as described here.
-	// The annotations associated with Cloud Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
+	// (Map of String) The annotations associated with Cloud Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
 	// +mapType=granular
 	Annotations map[string]*string `json:"annotations,omitempty" tf:"annotations,omitempty"`
 
-	// (Map of String) The labels associated with Cloud Foundry resources. Add as described here.
-	// The labels associated with Cloud Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
+	// (Map of String) The labels associated with Cloud Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
 	// +mapType=granular
 	Labels map[string]*string `json:"labels,omitempty" tf:"labels,omitempty"`
 
-	// (Attributes) The details of the last operation performed on the resource (see below for nested schema)
-	LastOperation  `json:"lastOperation,omitempty" tf:"last_operation,omitempty"`
+	// (Attributes) The details of the last operation performed on the resource.
+	LastOperation `json:"lastOperation,omitempty" tf:"last_operation,omitempty"`
 
-	// (Attributes) Information about the version of this service instance; only shown when type is managed (see below for nested schema)
+	// (Attributes) Information about the version of this service instance; only shown when `type` is `managed`.
 	MaintenanceInfo MaintenanceInfo `json:"maintenanceInfo,omitempty" tf:"maintenance_info,omitempty"`
 
-	// (String) The URL to the service instance dashboard (or null if there is none); only shown when type is managed.
-	// The URL to the service instance dashboard (or null if there is none); only shown when type is managed.
+	// (String) The URL to the service instance dashboard (or null if there is none); only shown when `type` is `managed`.
 	DashboardURL *string `json:"dashboardUrl,omitempty" tf:"dashboard_url,omitempty"`
 
-	// URL to which requests for bound routes will be forwarded; only shown when type is user-provided.
+	// (String) URL to which requests for bound routes will be forwarded; only shown when `type` is `user-provided`.
 	RouteServiceURL *string `json:"routeServiceUrl,omitempty" tf:"route_service_url,omitempty"`
 
-	// URL to which logs for bound applications will be streamed; only shown when type is user-provided.
+	// (String) URL to which logs for bound applications will be streamed; only shown when `type` is `user-provided`.
 	SyslogDrainURL *string `json:"syslogDrainUrl,omitempty" tf:"syslog_drain_url,omitempty"`
 
 	// (List of String) List of tags used by apps to identify service instances. They are shown in the app VCAP_SERVICES env.
-	// List of tags used by apps to identify service instances. They are shown in the app VCAP_SERVICES env.
 	Tags []*string `json:"tags,omitempty" tf:"tags,omitempty"`
 
 	// (String) The date and time when the resource was created in RFC3339 format.
-	// The date and time when the resource was created in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
 	CreatedAt *string `json:"createdAt,omitempty" tf:"created_at,omitempty"`
 
 	// (String) The date and time when the resource was updated in RFC3339 format.
-	// The date and time when the resource was updated in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
 	UpdatedAt *string `json:"updatedAt,omitempty" tf:"updated_at,omitempty"`
 
-	// (Boolean) Whether or not an upgrade of this service instance is available on the current Service Plan; details are available in the maintenance_info object; Only shown when type is managed
-	// Whether or not an upgrade of this service instance is available on the current Service Plan; details are available in the maintenance_info object; Only shown when type is managed
+	// (Boolean) Whether or not an upgrade of this service instance is available on the current service plan; details are available in the `maintenanceInfo` object; only shown when `type` is `managed`.
 	UpgradeAvailable *bool `json:"upgradeAvailable,omitempty" tf:"upgrade_available,omitempty"`
 }
 
-// MaintenanceInfo
+// MaintenanceInfo contains information about the version of this service instance.
 type MaintenanceInfo struct {
 
-	// (String) A description of the last operation
+	// (String) A description of the last operation.
 	// +kubebuilder:validation:Optional
 	Description *string `json:"description,omitempty" tf:"description,omitempty"`
 
-	// (String) The version of the service instance
+	// (String) The version of the service instance.
 	// +kubebuilder:validation:Optional
 	Version *string `json:"version,omitempty" tf:"version,omitempty"`
 }
 
-// ServicePlanParameters define a service plan
+// ServicePlanParameters defines a service plan for a managed service instance.
 type ServicePlanParameters struct {
-	// The ID of the service plan
+	// (String) The ID of the service plan from which to create the service instance.
 	// +optional
 	ID *string `json:"id"`
 
-	// The name of service offering
+	// (String) The name of the plan offering.
 	// +optional
 	Offering *string `json:"offering"`
 
-	// The name of service plan
+	// (String) The name of the service plan.
 	// +optional
 	Plan *string `json:"plan"`
 }
 
 type TimeoutsParameters struct {
 
-	// (String) Timeout for creating the service instance. Default is 40 minutes
+	// (String) Timeout for creating the service instance. Default is 40 minutes.
 	// +kubebuilder:validation:Optional
 	Create *string `json:"create,omitempty" tf:"create,omitempty"`
 
-	// (String) Timeout for deleting the service instance. Default is 40 minutes
+	// (String) Timeout for deleting the service instance. Default is 40 minutes.
 	// +kubebuilder:validation:Optional
 	Delete *string `json:"delete,omitempty" tf:"delete,omitempty"`
 
-	// (String) Timeout for updating the service instance. Default is 40 minutes
+	// (String) Timeout for updating the service instance. Default is 40 minutes.
 	// +kubebuilder:validation:Optional
 	Update *string `json:"update,omitempty" tf:"update,omitempty"`
 }
@@ -235,7 +214,7 @@ type ServiceInstanceSpec struct {
 	v1.ResourceSpec `json:",inline"`
 	ForProvider     ServiceInstanceParameters `json:"forProvider"`
 
-	// Enable drift detection for configuration parameters of managed service instance. Default is false.
+	// (Boolean) Enable drift detection for configuration parameters of managed service instance. Default is false.
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=false
 	EnableParameterDriftDetection bool `json:"enableParameterDriftDetection,omitempty"`
@@ -251,7 +230,7 @@ type ServiceInstanceStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
 
-// ServiceInstance is the Schema for the ServiceInstances API. Creates a service instance in a cloudfoundry space. Further documentation: https://docs.cloudfoundry.org/devguide/services
+// ServiceInstance is the Schema for the ServiceInstances API. Creates a service instance in a Cloud Foundry space. Further documentation: https://docs.cloudfoundry.org/devguide/services
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
@@ -260,8 +239,8 @@ type ServiceInstanceStatus struct {
 type ServiceInstance struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec   ServiceInstanceSpec   `json:"spec"`
-	Status ServiceInstanceStatus `json:"status,omitempty"`
+	Spec              ServiceInstanceSpec   `json:"spec"`
+	Status            ServiceInstanceStatus `json:"status,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -292,7 +271,6 @@ func (r *ServiceInstance) GetCloudFoundryName() string {
 	}
 	return *r.Spec.ForProvider.Name
 }
-
 
 // GetSpaceRef returns the reference to the space
 func (s *ServiceInstance) GetSpaceRef() *SpaceReference {

--- a/apis/resources/v1alpha1/space_quota_types.go
+++ b/apis/resources/v1alpha1/space_quota_types.go
@@ -14,229 +14,185 @@ import (
 )
 
 type SpaceQuotaInitParameters struct {
-
-	// free service plans. Does not control plan visibility. When false, non-free service plans may be visible in the marketplace but instances can not be provisioned.
-	// Determines whether users can provision instances of non-free service plans. Does not control plan visibility. When false, non-free service plans may be visible in the marketplace but instances can not be provisioned.
+	// (Boolean) Determines whether users can provision instances of non-free service plans. Does not control plan visibility. When false, non-free service plans may be visible in the marketplace but instances cannot be provisioned.
 	AllowPaidServicePlans *bool `json:"allowPaidServicePlans,omitempty" tf:"allow_paid_service_plans,omitempty"`
 
 	// (Number) Maximum memory per application instance.
-	// Maximum memory per application instance.
 	InstanceMemory *float64 `json:"instanceMemory,omitempty" tf:"instance_memory,omitempty"`
 
-	// (String) The name you use to identify the quota or plan in Cloud Foundry
-	// The name you use to identify the quota or plan in Cloud Foundry
+	// (String) The name you use to identify the quota or plan in Cloud Foundry.
 	Name *string `json:"name,omitempty" tf:"name,omitempty"`
 
-	// (String) The ID of the Org within which to create the space quota
-	// The ID of the Org within which to create the space quota
+	// (String) The ID of the Org within which to create the space quota.
 	Org *string `json:"org,omitempty" tf:"org,omitempty"`
 
-	// Reference to a Org in resources to populate org.
+	// (Attributes) Reference to an Org in resources to populate `org`.
 	// +kubebuilder:validation:Optional
 	OrgRef *v1.Reference `json:"orgRef,omitempty" tf:"-"`
 
-	// Selector for a Org in resources to populate org.
+	// (Attributes) Selector for an Org in resources to populate `org`.
 	// +kubebuilder:validation:Optional
 	OrgSelector *v1.Selector `json:"orgSelector,omitempty" tf:"-"`
 
 	// (Set of String) Set of space GUIDs to which this space quota would be assigned.
-	// Set of space GUIDs to which this space quota would be assigned.
 	// +crossplane:generate:reference:type=github.com/SAP/crossplane-provider-cloudfoundry/apis/resources/v1alpha1.Space
 	// +crossplane:generate:reference:extractor=github.com/SAP/crossplane-provider-cloudfoundry/apis/resources.ExternalID()
 	// +listType=set
 	Spaces []*string `json:"spaces,omitempty" tf:"spaces,omitempty"`
 
-	// References to Space in cloudfoundry to populate spaces.
+	// (Attributes) References to Space in cloudfoundry to populate `spaces`.
 	// +kubebuilder:validation:Optional
 	SpacesRefs []v1.Reference `json:"spacesRefs,omitempty" tf:"-"`
 
-	// Selector for a list of Space in cloudfoundry to populate spaces.
+	// (Attributes) Selector for a list of Space in cloudfoundry to populate `spaces`.
 	// +kubebuilder:validation:Optional
 	SpacesSelector *v1.Selector `json:"spacesSelector,omitempty" tf:"-"`
 
 	// (Number) Maximum app instances allowed.
-	// Maximum app instances allowed.
 	TotalAppInstances *float64 `json:"totalAppInstances,omitempty" tf:"total_app_instances,omitempty"`
 
 	// (Number) Maximum log rate allowed for all the started processes and running tasks in bytes/second.
-	// Maximum log rate allowed for all the started processes and running tasks in bytes/second.
 	TotalAppLogRateLimit *float64 `json:"totalAppLogRateLimit,omitempty" tf:"total_app_log_rate_limit,omitempty"`
 
 	// (Number) Maximum tasks allowed per app.
-	// Maximum tasks allowed per app.
 	TotalAppTasks *float64 `json:"totalAppTasks,omitempty" tf:"total_app_tasks,omitempty"`
 
 	// (Number) Maximum memory usage allowed.
-	// Maximum memory usage allowed.
 	TotalMemory *float64 `json:"totalMemory,omitempty" tf:"total_memory,omitempty"`
 
 	// (Number) Total number of ports that are reservable by routes in a space.
-	// Total number of ports that are reservable by routes in a space.
 	TotalRoutePorts *float64 `json:"totalRoutePorts,omitempty" tf:"total_route_ports,omitempty"`
 
 	// (Number) Maximum routes allowed.
-	// Maximum routes allowed.
 	TotalRoutes *float64 `json:"totalRoutes,omitempty" tf:"total_routes,omitempty"`
 
 	// (Number) Maximum service keys allowed.
-	// Maximum service keys allowed.
 	TotalServiceKeys *float64 `json:"totalServiceKeys,omitempty" tf:"total_service_keys,omitempty"`
 
 	// (Number) Maximum services allowed.
-	// Maximum services allowed.
 	TotalServices *float64 `json:"totalServices,omitempty" tf:"total_services,omitempty"`
 }
 
 type SpaceQuotaObservation struct {
-
-	// free service plans. Does not control plan visibility. When false, non-free service plans may be visible in the marketplace but instances can not be provisioned.
-	// Determines whether users can provision instances of non-free service plans. Does not control plan visibility. When false, non-free service plans may be visible in the marketplace but instances can not be provisioned.
+	// (Boolean) Determines whether users can provision instances of non-free service plans. Does not control plan visibility. When false, non-free service plans may be visible in the marketplace but instances cannot be provisioned.
 	AllowPaidServicePlans *bool `json:"allowPaidServicePlans,omitempty" tf:"allow_paid_service_plans,omitempty"`
 
-	// (String) The date and time when the resource was created in RFC3339 format.
-	// The date and time when the resource was created in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
+	// (String) The date and time when the resource was created in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
 	CreatedAt *string `json:"createdAt,omitempty" tf:"created_at,omitempty"`
 
 	// (String) The GUID of the object.
 	ID *string `json:"id,omitempty" tf:"id,omitempty"`
 
 	// (Number) Maximum memory per application instance.
-	// Maximum memory per application instance.
 	InstanceMemory *float64 `json:"instanceMemory,omitempty" tf:"instance_memory,omitempty"`
 
-	// (String) The name you use to identify the quota or plan in Cloud Foundry
-	// The name you use to identify the quota or plan in Cloud Foundry
+	// (String) The name you use to identify the quota or plan in Cloud Foundry.
 	Name *string `json:"name,omitempty" tf:"name,omitempty"`
 
-	// (String) The ID of the Org within which to create the space quota
-	// The ID of the Org within which to create the space quota
+	// (String) The ID of the Org within which to create the space quota.
 	Org *string `json:"org,omitempty" tf:"org,omitempty"`
 
 	// (Set of String) Set of space GUIDs to which this space quota would be assigned.
-	// Set of space GUIDs to which this space quota would be assigned.
 	// +listType=set
 	Spaces []*string `json:"spaces,omitempty" tf:"spaces,omitempty"`
 
 	// (Number) Maximum app instances allowed.
-	// Maximum app instances allowed.
 	TotalAppInstances *float64 `json:"totalAppInstances,omitempty" tf:"total_app_instances,omitempty"`
 
 	// (Number) Maximum log rate allowed for all the started processes and running tasks in bytes/second.
-	// Maximum log rate allowed for all the started processes and running tasks in bytes/second.
 	TotalAppLogRateLimit *float64 `json:"totalAppLogRateLimit,omitempty" tf:"total_app_log_rate_limit,omitempty"`
 
 	// (Number) Maximum tasks allowed per app.
-	// Maximum tasks allowed per app.
 	TotalAppTasks *float64 `json:"totalAppTasks,omitempty" tf:"total_app_tasks,omitempty"`
 
 	// (Number) Maximum memory usage allowed.
-	// Maximum memory usage allowed.
 	TotalMemory *float64 `json:"totalMemory,omitempty" tf:"total_memory,omitempty"`
 
 	// (Number) Total number of ports that are reservable by routes in a space.
-	// Total number of ports that are reservable by routes in a space.
 	TotalRoutePorts *float64 `json:"totalRoutePorts,omitempty" tf:"total_route_ports,omitempty"`
 
 	// (Number) Maximum routes allowed.
-	// Maximum routes allowed.
 	TotalRoutes *float64 `json:"totalRoutes,omitempty" tf:"total_routes,omitempty"`
 
 	// (Number) Maximum service keys allowed.
-	// Maximum service keys allowed.
 	TotalServiceKeys *float64 `json:"totalServiceKeys,omitempty" tf:"total_service_keys,omitempty"`
 
 	// (Number) Maximum services allowed.
-	// Maximum services allowed.
 	TotalServices *float64 `json:"totalServices,omitempty" tf:"total_services,omitempty"`
 
-	// (String) The date and time when the resource was updated in RFC3339 format.
-	// The date and time when the resource was updated in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
+	// (String) The date and time when the resource was updated in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
 	UpdatedAt *string `json:"updatedAt,omitempty" tf:"updated_at,omitempty"`
 }
 
 type SpaceQuotaParameters struct {
-
-	// free service plans. Does not control plan visibility. When false, non-free service plans may be visible in the marketplace but instances can not be provisioned.
-	// Determines whether users can provision instances of non-free service plans. Does not control plan visibility. When false, non-free service plans may be visible in the marketplace but instances can not be provisioned.
+	// (Boolean) Determines whether users can provision instances of non-free service plans. Does not control plan visibility. When false, non-free service plans may be visible in the marketplace but instances cannot be provisioned.
 	// +kubebuilder:validation:Optional
 	AllowPaidServicePlans *bool `json:"allowPaidServicePlans,omitempty" tf:"allow_paid_service_plans,omitempty"`
 
 	// (Number) Maximum memory per application instance.
-	// Maximum memory per application instance.
 	// +kubebuilder:validation:Optional
 	InstanceMemory *float64 `json:"instanceMemory,omitempty" tf:"instance_memory,omitempty"`
 
-	// (String) The name you use to identify the quota or plan in Cloud Foundry
-	// The name you use to identify the quota or plan in Cloud Foundry
+	// (String) The name you use to identify the quota or plan in Cloud Foundry.
 	// +kubebuilder:validation:Optional
 	Name *string `json:"name,omitempty" tf:"name,omitempty"`
 
-	// (String) The ID of the Org within which to create the space quota
-	// The ID of the Org within which to create the space quota
+	// (String) The ID of the Org within which to create the space quota.
 	// +kubebuilder:validation:Optional
 	Org *string `json:"org,omitempty" tf:"org,omitempty"`
 
-	// Reference to a Org in resources to populate org.
+	// (Attributes) Reference to an Org in resources to populate `org`.
 	// +kubebuilder:validation:Optional
 	OrgRef *v1.Reference `json:"orgRef,omitempty" tf:"-"`
 
-	// Selector for a Org in resources to populate org.
+	// (Attributes) Selector for an Org in resources to populate `org`.
 	// +kubebuilder:validation:Optional
 	OrgSelector *v1.Selector `json:"orgSelector,omitempty" tf:"-"`
 
 	// (Set of String) Set of space GUIDs to which this space quota would be assigned.
-	// Set of space GUIDs to which this space quota would be assigned.
 	// +crossplane:generate:reference:type=github.com/SAP/crossplane-provider-cloudfoundry/apis/resources/v1alpha1.Space
 	// +crossplane:generate:reference:extractor=github.com/SAP/crossplane-provider-cloudfoundry/apis/resources.ExternalID()
 	// +kubebuilder:validation:Optional
 	// +listType=set
 	Spaces []*string `json:"spaces,omitempty" tf:"spaces,omitempty"`
 
-	// References to Space in cloudfoundry to populate spaces.
+	// (Attributes) References to Space in cloudfoundry to populate `spaces`.
 	// +kubebuilder:validation:Optional
 	SpacesRefs []v1.Reference `json:"spacesRefs,omitempty" tf:"-"`
 
-	// Selector for a list of Space in cloudfoundry to populate spaces.
+	// (Attributes) Selector for a list of Space in cloudfoundry to populate `spaces`.
 	// +kubebuilder:validation:Optional
 	SpacesSelector *v1.Selector `json:"spacesSelector,omitempty" tf:"-"`
 
 	// (Number) Maximum app instances allowed.
-	// Maximum app instances allowed.
 	// +kubebuilder:validation:Optional
 	TotalAppInstances *float64 `json:"totalAppInstances,omitempty" tf:"total_app_instances,omitempty"`
 
 	// (Number) Maximum log rate allowed for all the started processes and running tasks in bytes/second.
-	// Maximum log rate allowed for all the started processes and running tasks in bytes/second.
 	// +kubebuilder:validation:Optional
 	TotalAppLogRateLimit *float64 `json:"totalAppLogRateLimit,omitempty" tf:"total_app_log_rate_limit,omitempty"`
 
 	// (Number) Maximum tasks allowed per app.
-	// Maximum tasks allowed per app.
 	// +kubebuilder:validation:Optional
 	TotalAppTasks *float64 `json:"totalAppTasks,omitempty" tf:"total_app_tasks,omitempty"`
 
 	// (Number) Maximum memory usage allowed.
-	// Maximum memory usage allowed.
 	// +kubebuilder:validation:Optional
 	TotalMemory *float64 `json:"totalMemory,omitempty" tf:"total_memory,omitempty"`
 
 	// (Number) Total number of ports that are reservable by routes in a space.
-	// Total number of ports that are reservable by routes in a space.
 	// +kubebuilder:validation:Optional
 	TotalRoutePorts *float64 `json:"totalRoutePorts,omitempty" tf:"total_route_ports,omitempty"`
 
 	// (Number) Maximum routes allowed.
-	// Maximum routes allowed.
 	// +kubebuilder:validation:Optional
 	TotalRoutes *float64 `json:"totalRoutes,omitempty" tf:"total_routes,omitempty"`
 
 	// (Number) Maximum service keys allowed.
-	// Maximum service keys allowed.
 	// +kubebuilder:validation:Optional
 	TotalServiceKeys *float64 `json:"totalServiceKeys,omitempty" tf:"total_service_keys,omitempty"`
 
 	// (Number) Maximum services allowed.
-	// Maximum services allowed.
 	// +kubebuilder:validation:Optional
 	TotalServices *float64 `json:"totalServices,omitempty" tf:"total_services,omitempty"`
 }

--- a/apis/resources/v1alpha1/space_types.go
+++ b/apis/resources/v1alpha1/space_types.go
@@ -16,85 +16,71 @@ import (
 type SpaceObservation struct {
 
 	// (Boolean) Allows SSH to application containers via the CF CLI.
-	// Allows SSH to application containers via the CF CLI.
 	AllowSSH bool `json:"allowSsh,omitempty" tf:"allow_ssh,omitempty"`
 
-	// (Map of String) The annotations associated with Cloud Foundry resources. Add as described here.
-	// The annotations associated with Cloud Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
+	// (Map of String) The annotations associated with Cloud Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
 	// +mapType=granular
 	Annotations map[string]*string `json:"annotations,omitempty" tf:"annotations,omitempty"`
 
-	// (String) The date and time when the resource was created in RFC3339 format.
-	// The date and time when the resource was created in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
+	// (String) The date and time when the resource was created in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
 	CreatedAt *string `json:"createdAt,omitempty" tf:"created_at,omitempty"`
 
 	// (String) The GUID of the object.
 	ID string `json:"id,omitempty"`
 
-	// (String) The ID of the isolation segment to assign to the space. The isolation segment must be entitled to the space's parent organization
-	// The ID of the isolation segment to assign to the space. The isolation segment must be entitled to the space's parent organization
+	// (String) The ID of the isolation segment to assign to the space. The isolation segment must be entitled to the space's parent organization.
 	IsolationSegment *string `json:"isolationSegment,omitempty" tf:"isolation_segment,omitempty"`
 
-	// (Map of String) The labels associated with Cloud Foundry resources. Add as described here.
-	// The labels associated with Cloud Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
+	// (Map of String) The labels associated with Cloud Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
 	// +mapType=granular
 	Labels map[string]*string `json:"labels,omitempty" tf:"labels,omitempty"`
 
-	// (String) The name of the Space in Cloud Foundry
-	// The name of the Space in Cloud Foundry
+	// (String) The name of the space in Cloud Foundry.
 	Name string `json:"name,omitempty" tf:"name,omitempty"`
 
-	// (String) The ID of the Org within which to create the space
-	// The ID of the Org within which to create the space
+	// (String) The ID of the organization within which to create the space.
 	Org string `json:"org,omitempty" tf:"org,omitempty"`
 
 	// (String) The space quota applied to the space. To assign a space quota, use the space quota resource instead.
-	// The space quota applied to the space. To assign a space quota, use the space quota resource instead.
 	Quota *string `json:"quota,omitempty" tf:"quota,omitempty"`
 
-	// (String) The date and time when the resource was updated in RFC3339 format.
-	// The date and time when the resource was updated in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
+	// (String) The date and time when the resource was updated in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
 	UpdatedAt *string `json:"updatedAt,omitempty" tf:"updated_at,omitempty"`
 }
 
 type SpaceParameters struct {
 
 	// (Boolean) Allows SSH to application containers via the CF CLI.
-	// Allows SSH to application containers via the CF CLI.
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=false
 	AllowSSH bool `json:"allowSsh,omitempty" tf:"allow_ssh,omitempty"`
 
-	// (Map of String) The annotations associated with Cloud Foundry resources. Add as described here.
-	// The annotations associated with Cloud Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
+	// (Map of String) The annotations associated with Cloud Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
 	// +kubebuilder:validation:Optional
 	// +mapType=granular
 	Annotations map[string]*string `json:"annotations,omitempty" tf:"annotations,omitempty"`
 
-	// (String) The ID of the isolation segment to assign to the space. The isolation segment must be entitled to the space's parent organization
-	// The ID of the isolation segment to assign to the space. The isolation segment must be entitled to the space's parent organization
+	// (String) The ID of the isolation segment to assign to the space. The isolation segment must be entitled to the space's parent organization.
 	// +kubebuilder:validation:Optional
 	IsolationSegment *string `json:"isolationSegment,omitempty" tf:"isolation_segment,omitempty"`
 
-	// (Map of String) The labels associated with Cloud Foundry resources. Add as described here.
-	// The labels associated with Cloud Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
+	// (Map of String) The labels associated with Cloud Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
 	// +kubebuilder:validation:Optional
 	// +mapType=granular
 	Labels map[string]*string `json:"labels,omitempty" tf:"labels,omitempty"`
 
-	// (String) The name of the Space in Cloud Foundry
-	// The name of the Space in Cloud Foundry
+	// (String) The name of the space in Cloud Foundry.
 	// +kubebuilder:validation:Required
 	Name string `json:"name,omitempty" tf:"name,omitempty"`
 
+	// (Attributes) Reference to the organization in which to create the space.
 	OrgReference `json:",inline"`
 }
 
-// SpaceSpec defines the desired state of Space
+// SpaceSpec defines the desired state of Space.
 type SpaceSpec struct {
 	v1.ResourceSpec `json:",inline"`
 	ForProvider     SpaceParameters `json:"forProvider"`
-
 }
 
 // SpaceStatus defines the observed state of Space.
@@ -123,7 +109,7 @@ type Space struct {
 
 // +kubebuilder:object:root=true
 
-// SpaceList contains a list of Spaces
+// SpaceList contains a list of Spaces.
 type SpaceList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/apis/resources/v1alpha1/spacemember_types.go
+++ b/apis/resources/v1alpha1/spacemember_types.go
@@ -7,19 +7,21 @@ import (
 	v1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 )
 
-// SpaceMembersParameters encapsulate role assignments to CloudFoundry Spaces
+// SpaceMembersParameters encapsulate role assignments to CloudFoundry Spaces.
 type SpaceMembersParameters struct {
+	// (Attributes) Reference to the Cloud Foundry space.
 	SpaceReference `json:",inline"`
 
-	// Space role type to assign to members; see valid role types https://v3-apidocs.cloudfoundry.space/version/3.127.0/index.html#valid-role-types
+	// (String) Space role type to assign to members; see valid role types https://v3-apidocs.cloudfoundry.space/version/3.127.0/index.html#valid-role-types
 	// +kubebuilder:validation:Enum=Developer;Auditor;Manager;Supporter;Developers;Auditors;Managers;Supporters
 	// +kubebuilder:validation:Required
 	RoleType string `json:"roleType"`
 
+	// (Attributes) List of members and enforcement policy for role assignment.
 	MemberList `json:",inline"`
 }
 
-// SpaceMembersSpec defines the desired state of SpaceMembers
+// SpaceMembersSpec defines the desired state of SpaceMembers.
 type SpaceMembersSpec struct {
 	v1.ResourceSpec `json:",inline"`
 	ForProvider     SpaceMembersParameters `json:"forProvider"`
@@ -28,7 +30,8 @@ type SpaceMembersSpec struct {
 // SpaceMembersStatus defines the observed state of SpaceMembers.
 type SpaceMembersStatus struct {
 	v1.ResourceStatus `json:",inline"`
-	AtProvider        RoleAssignments `json:"atProvider,omitempty"`
+	// (Attributes) The assigned roles for the space members.
+	AtProvider RoleAssignments `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -49,7 +52,7 @@ type SpaceMembers struct {
 
 // +kubebuilder:object:root=true
 
-// SpaceMembersList contains a list of SpaceMembers
+// SpaceMembersList contains a list of SpaceMembers.
 type SpaceMembersList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/apis/resources/v1alpha1/spacerole_types.go
+++ b/apis/resources/v1alpha1/spacerole_types.go
@@ -14,61 +14,50 @@ import (
 )
 
 type SpaceRoleObservation struct {
-
-	// (String) The date and time when the resource was created in RFC3339 format.
-	// The date and time when the resource was created in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
+	// (String) The date and time when the resource was created in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
 	CreatedAt *string `json:"createdAt,omitempty" tf:"created_at,omitempty"`
 
 	// (String) The GUID of the object.
 	ID *string `json:"id,omitempty" tf:"id,omitempty"`
 
-	// (String) The identity provider for the UAA user
-	// The identity provider for the UAA user
+	// (String) The identity provider for the UAA user.
 	Origin *string `json:"origin,omitempty" tf:"origin,omitempty"`
 
-	// (String) SpaceRole type; see Valid role types
+	// (String) The space role type; see [Valid role types](https://v3-apidocs.cloudfoundry.org/version/3.154.0/index.html#valid-role-types).
 	Type *string `json:"type,omitempty" tf:"type,omitempty"`
 
-	// (String) The date and time when the resource was updated in RFC3339 format.
-	// The date and time when the resource was updated in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
+	// (String) The date and time when the resource was updated in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
 	UpdatedAt *string `json:"updatedAt,omitempty" tf:"updated_at,omitempty"`
 
-	// (String) The guid of the cloudfoundry user to assign the role with
-	// The guid of the cloudfoundry user to assign the role with
+	// (String) The GUID of the Cloud Foundry user to assign the role to.
 	User *string `json:"user,omitempty" tf:"user,omitempty"`
 
-	// (String) The username of the cloudfoundry user to assign the role with
-	// The username of the cloudfoundry user to assign the role with
+	// (String) The username of the Cloud Foundry user to assign the role to.
 	Username *string `json:"username,omitempty" tf:"username,omitempty"`
 }
 
 type SpaceRoleParameters struct {
-
+	// (Attributes) Reference to the Cloud Foundry space.
 	SpaceReference `json:",inline"`
 
-	// (String) SpaceRole type; see Valid role types
-	// SpaceRole type; see [Valid role types](https://v3-apidocs.cloudfoundry.org/version/3.154.0/index.html#valid-role-types)
+	// (String) The space role type; see [Valid role types](https://v3-apidocs.cloudfoundry.org/version/3.154.0/index.html#valid-role-types).
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Enum=Developer;Auditor;Manager;Supporter;Developers;Auditors;Managers;Supporters
 	Type string `json:"type,omitempty" tf:"type,omitempty"`
 
-	// (String) The identity provider for the UAA user
-	// The identity provider for the UAA user
+	// (String) The identity provider for the UAA user.
 	// +kubebuilder:validation:Optional
 	Origin *string `json:"origin,omitempty" tf:"origin,omitempty"`
 
-	// (String) The username of the cloudfoundry user to assign the role with
-	// The username of the cloudfoundry user to assign the role with
+	// (String) The username of the Cloud Foundry user to assign the role to.
 	// +kubebuilder:validation:Required
 	Username string `json:"username,omitempty" tf:"username,omitempty"`
-
 }
 
 // SpaceRoleSpec defines the desired state of SpaceRole
 type SpaceRoleSpec struct {
 	v1.ResourceSpec `json:",inline"`
 	ForProvider     SpaceRoleParameters `json:"forProvider"`
-
 }
 
 // SpaceRoleStatus defines the observed state of SpaceRole.
@@ -90,8 +79,8 @@ type SpaceRoleStatus struct {
 type SpaceRole struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec   SpaceRoleSpec   `json:"spec"`
-	Status SpaceRoleStatus `json:"status,omitempty"`
+	Spec              SpaceRoleSpec   `json:"spec"`
+	Status            SpaceRoleStatus `json:"status,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/package/crds/cloudfoundry.crossplane.io_apps.yaml
+++ b/package/crds/cloudfoundry.crossplane.io_apps.yaml
@@ -76,8 +76,8 @@ spec:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: The annotations associated with Cloud Foundry resources.
-                      Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
+                    description: (Map of String) The annotations associated with the
+                      resource. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
                     type: object
                   buildpacks:
                     description: (NOT SUPPORTED YET) An array of one ore more installed
@@ -122,13 +122,13 @@ spec:
                   labels:
                     additionalProperties:
                       type: string
-                    description: The labels associated with Cloud Foundry resources.
+                    description: (Map of String) The labels associated with the resource.
                       Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
                     type: object
                   lifecycle:
                     default: buildpack
-                    description: Type of the lifecycle; valid values are `buildpack``,
-                      `cnb``, `docker``
+                    description: Type of the lifecycle; valid values are `buildpack`,
+                      `cnb`, `docker`
                     enum:
                     - buildpack
                     - cnb
@@ -140,7 +140,7 @@ spec:
                       MB, G, or GB, in either uppercase or lowercase.'
                     type: string
                   name:
-                    description: The name of the application.
+                    description: The `name` of the application.
                     type: string
                   no-route:
                     description: When set to true, any routes configuration specified
@@ -148,8 +148,8 @@ spec:
                       be removed.
                     type: boolean
                   orgName:
-                    description: The name of the Cloud Foundry organization containing
-                      the space.
+                    description: (String) The name of the Cloud Foundry organization
+                      containing the space.
                     type: string
                   path:
                     description: (NOT SUPPORTED YET) The path to the app directory
@@ -424,19 +424,19 @@ spec:
                       type: object
                     type: array
                   space:
-                    description: The `guid` of the Cloud Foundry space. This field
-                      is typically populated using references specified in `spaceRef`,
+                    description: (String) The GUID of the Cloud Foundry space. This
+                      field is typically populated using references specified in `spaceRef`,
                       `spaceSelector`, or `spaceName`.
                     type: string
                   spaceName:
-                    description: The name of the Cloud Foundry space to lookup the
-                      `guid` of the Space. Use `spaceName` only when the reference
-                      Space is not managed by Crossplane.
+                    description: (String) The name of the Cloud Foundry space to lookup
+                      the GUID of the space. Use `spaceName` only when the referenced
+                      space is not managed by Crossplane.
                     type: string
                   spaceRef:
-                    description: Reference to a `Space` CR to lookup the `guid` of
-                      the Cloud Foundry space. Preferred if the reference space is
-                      managed by Crossplane.
+                    description: (Attributes) Reference to a `Space` CR to lookup
+                      the GUID of the Cloud Foundry space. Preferred if the referenced
+                      space is managed by Crossplane.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -470,9 +470,9 @@ spec:
                     - name
                     type: object
                   spaceSelector:
-                    description: Selector for a `Space` CR to lookup the `guid` of
-                      the Cloud Foundry space. Preferred if the reference space is
-                      managed by Crossplane.
+                    description: (Attributes) Selector for a `Space` CR to lookup
+                      the GUID of the Cloud Foundry space. Preferred if the referenced
+                      space is managed by Crossplane.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -692,21 +692,21 @@ spec:
                     description: The yaml representation of the environment variables.
                     type: string
                   createdAt:
-                    description: The date and time when the resource was created in
-                      [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
+                    description: (String) The date and time when the resource was
+                      created in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
                     type: string
                   guid:
-                    description: The GUID of the Cloud Foundry resource
+                    description: (String) The GUID of the Cloud Foundry resource.
                     type: string
                   name:
-                    description: The name of the application.
+                    description: The `name` of the application.
                     type: string
                   state:
-                    description: the State of the application.
+                    description: the `state` of the application.
                     type: string
                   updatedAt:
-                    description: The date and time when the resource was updated in
-                      [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
+                    description: (String) The date and time when the resource was
+                      updated in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
                     type: string
                 type: object
               conditions:

--- a/package/crds/cloudfoundry.crossplane.io_domains.yaml
+++ b/package/crds/cloudfoundry.crossplane.io_domains.yaml
@@ -76,45 +76,42 @@ spec:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: |-
-                      (Map of String) The annotations associated with Cloud Foundry resources. Add as described here.
-                      The annotations associated with Cloud Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
+                    description: (Map of String) The annotations associated with Cloud
+                      Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
                     type: object
                     x-kubernetes-map-type: granular
                   domain:
                     description: (Deprecated) Domain part of full domain name. If
-                      specified the sub_domain argument needs to be provided and the
-                      name will be computed. If name is provided, domain and sub_domain
-                      will be ignored.
+                      specified, the `subDomain` argument needs to be provided and
+                      the `name` will be computed. If `name` is provided, `domain`
+                      and `subDomain` will be ignored.
                     type: string
                   internal:
-                    description: |-
-                      (to-container) traffic, or external (user-to-container) traffic
-                      Whether the domain is used for internal (container-to-container) traffic, or external (user-to-container) traffic
+                    description: (Boolean) Whether the domain is used for internal
+                      (container-to-container) traffic, or external (user-to-container)
+                      traffic.
                     type: boolean
                   labels:
                     additionalProperties:
                       type: string
-                    description: |-
-                      (Map of String) The labels associated with Cloud Foundry resources. Add as described here.
-                      The labels associated with Cloud Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
+                    description: (Map of String) The labels associated with Cloud
+                      Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
                     type: object
                     x-kubernetes-map-type: granular
                   name:
-                    description: |-
-                      (String) The name of the domain;must be between 3 ~ 253 characters and follow RFC 1035
-                      The name of the domain;must be between 3 ~ 253 characters and follow [RFC 1035](https://tools.ietf.org/html/rfc1035).
+                    description: (String) The name of the domain; must be between
+                      3 ~ 253 characters and follow [RFC 1035](https://tools.ietf.org/html/rfc1035).
                     type: string
                   org:
-                    description: (String) The guid of the organization
+                    description: (String) The GUID of the organization.
                     type: string
                   orgName:
-                    description: The name of the Cloud Foundry organization containing
-                      the space.
+                    description: (String) The name of the Cloud Foundry organization
+                      containing the space.
                     type: string
                   orgRef:
-                    description: Reference to an `Org` CR to retrieve the external
-                      GUID of the organization.
+                    description: (Attributes) Reference to an `Org` CR to retrieve
+                      the external GUID of the organization.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -148,8 +145,8 @@ spec:
                     - name
                     type: object
                   orgSelector:
-                    description: Selector to an `Org` CR to retrieve the external
-                      GUID of the Organization.
+                    description: (Attributes) Selector to an `Org` CR to retrieve
+                      the external GUID of the organization.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -189,23 +186,23 @@ spec:
                         type: object
                     type: object
                   routerGroup:
-                    description: |-
-                      (String) The desired router group guid. note: creates a tcp domain; cannot be used when internal is set to true or domain is scoped to an org
-                      The desired router group guid. note: creates a tcp domain; cannot be used when internal is set to true or domain is scoped to an org
+                    description: '(String) The desired router group guid. Note: creates
+                      a TCP domain; cannot be used when `internal` is set to true
+                      or domain is scoped to an org.'
                     type: string
                   sharedOrgs:
-                    description: |-
-                      (Set of String) Organizations the domain is shared with; if set, the domain will be available in these organizations in addition to the organization the domain is scoped to
-                      Organizations the domain is shared with; if set, the domain will be available in these organizations in addition to the organization the domain is scoped to
+                    description: (Set of String) Organizations the domain is shared
+                      with; if set, the domain will be available in these organizations
+                      in addition to the organization the domain is scoped to.
                     items:
                       type: string
                     type: array
                     x-kubernetes-list-type: set
                   subDomain:
                     description: (Deprecated) Sub-domain part of full domain name.
-                      If specified the domain argument needs to be provided and the
-                      name will be computed. If name is provided, domain and sub_domain
-                      will be ignored.
+                      If specified, the `domain` argument needs to be provided and
+                      the `name` will be computed. If `name` is provided, `domain`
+                      and `subDomain` will be ignored.
                     type: string
                 type: object
               managementPolicies:
@@ -383,67 +380,61 @@ spec:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: |-
-                      (Map of String) The annotations associated with Cloud Foundry resources. Add as described here.
-                      The annotations associated with Cloud Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
+                    description: (Map of String) The annotations associated with Cloud
+                      Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
                     type: object
                     x-kubernetes-map-type: granular
                   createdAt:
-                    description: |-
-                      (String) The date and time when the resource was created in RFC3339 format.
-                      The date and time when the resource was created in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
+                    description: (String) The date and time when the resource was
+                      created in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
                     type: string
                   id:
                     description: (String) The GUID of the object.
                     type: string
                   internal:
-                    description: |-
-                      (to-container) traffic, or external (user-to-container) traffic
-                      Whether the domain is used for internal (container-to-container) traffic, or external (user-to-container) traffic
+                    description: (Boolean) Whether the domain is used for internal
+                      (container-to-container) traffic, or external (user-to-container)
+                      traffic.
                     type: boolean
                   labels:
                     additionalProperties:
                       type: string
-                    description: |-
-                      (Map of String) The labels associated with Cloud Foundry resources. Add as described here.
-                      The labels associated with Cloud Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
+                    description: (Map of String) The labels associated with Cloud
+                      Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
                     type: object
                     x-kubernetes-map-type: granular
                   name:
-                    description: |-
-                      (String) The name of the domain;must be between 3 ~ 253 characters and follow RFC 1035
-                      The name of the domain;must be between 3 ~ 253 characters and follow [RFC 1035](https://tools.ietf.org/html/rfc1035)
+                    description: (String) The name of the domain; must be between
+                      3 ~ 253 characters and follow [RFC 1035](https://tools.ietf.org/html/rfc1035).
                     type: string
                   org:
-                    description: |-
-                      (String) The organization the domain is scoped to; if set, the domain will only be available in that organization; otherwise, the domain will be globally available
-                      The organization the domain is scoped to; if set, the domain will only be available in that organization; otherwise, the domain will be globally available
+                    description: (String) The organization the domain is scoped to;
+                      if set, the domain will only be available in that organization;
+                      otherwise, the domain will be globally available.
                     type: string
                   routerGroup:
-                    description: |-
-                      (String) The desired router group guid. note: creates a tcp domain; cannot be used when internal is set to true or domain is scoped to an org
-                      The desired router group guid. note: creates a tcp domain; cannot be used when internal is set to true or domain is scoped to an org
+                    description: '(String) The desired router group guid. Note: creates
+                      a TCP domain; cannot be used when `internal` is set to true
+                      or domain is scoped to an org.'
                     type: string
                   sharedOrgs:
-                    description: |-
-                      (Set of String) Organizations the domain is shared with; if set, the domain will be available in these organizations in addition to the organization the domain is scoped to
-                      Organizations the domain is shared with; if set, the domain will be available in these organizations in addition to the organization the domain is scoped to
+                    description: (Set of String) Organizations the domain is shared
+                      with; if set, the domain will be available in these organizations
+                      in addition to the organization the domain is scoped to.
                     items:
                       type: string
                     type: array
                     x-kubernetes-list-type: set
                   supportedProtocols:
-                    description: |-
-                      (Set of String) Available protocols for routes using the domain, currently http and tcp
-                      Available protocols for routes using the domain, currently http and tcp
+                    description: (Set of String) Available protocols for routes using
+                      the domain, currently http and tcp.
                     items:
                       type: string
                     type: array
                     x-kubernetes-list-type: set
                   updatedAt:
-                    description: |-
-                      (String) The date and time when the resource was updated in RFC3339 format.
-                      The date and time when the resource was updated in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
+                    description: (String) The date and time when the resource was
+                      updated in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
                     type: string
                 type: object
               conditions:

--- a/package/crds/cloudfoundry.crossplane.io_organizations.yaml
+++ b/package/crds/cloudfoundry.crossplane.io_organizations.yaml
@@ -75,28 +75,23 @@ spec:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: |-
-                      (Map of String) The annotations associated with Cloud Foundry resources. Add as described here.
-                      The annotations associated with Cloud Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
+                    description: (Map of String) The annotations associated with Cloud
+                      Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
                     type: object
                     x-kubernetes-map-type: granular
                   labels:
                     additionalProperties:
                       type: string
-                    description: |-
-                      (Map of String) The labels associated with Cloud Foundry resources. Add as described here.
-                      The labels associated with Cloud Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
+                    description: (Map of String) The labels associated with Cloud
+                      Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
                     type: object
                     x-kubernetes-map-type: granular
                   name:
-                    description: |-
-                      (String) The name of the Organization in Cloud Foundry
-                      The name of the Organization in Cloud Foundry
+                    description: (String) The name of the Organization in Cloud Foundry.
                     type: string
                   suspended:
-                    description: |-
-                      (Boolean) Whether an organization is suspended or not.
-                      Whether an organization is suspended or not.
+                    description: (Boolean) Whether an Organization is suspended or
+                      not.
                     type: boolean
                 type: object
               managementPolicies:
@@ -274,46 +269,38 @@ spec:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: |-
-                      (Map of String) The annotations associated with Cloud Foundry resources. Add as described here.
-                      The annotations associated with Cloud Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
+                    description: (Map of String) The annotations associated with Cloud
+                      Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
                     type: object
                     x-kubernetes-map-type: granular
                   createdAt:
-                    description: |-
-                      (String) The date and time when the resource was created in RFC3339 format.
-                      The date and time when the resource was created in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
+                    description: (String) The date and time when the resource was
+                      created in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
                     type: string
                   id:
-                    description: (String) The ID of the Organization
+                    description: (String) The ID of the Organization.
                     type: string
                   labels:
                     additionalProperties:
                       type: string
-                    description: |-
-                      (Map of String) The labels associated with Cloud Foundry resources. Add as described here.
-                      The labels associated with Cloud Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
+                    description: (Map of String) The labels associated with Cloud
+                      Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
                     type: object
                     x-kubernetes-map-type: granular
                   name:
-                    description: |-
-                      (String) The name of the Organization in Cloud Foundry
-                      The name of the Organization in Cloud Foundry
+                    description: (String) The name of the Organization in Cloud Foundry.
                     type: string
                   quota:
-                    description: |-
-                      (String) The ID of quota to be applied to this Org. Default quota is assigned to the org by default.
-                      The ID of quota to be applied to this Org. Default quota is assigned to the org by default.
+                    description: (String) The ID of quota to be applied to this Organization.
+                      Default quota is assigned to the Organization by default.
                     type: string
                   suspended:
-                    description: |-
-                      (Boolean) Whether an organization is suspended or not.
-                      Whether an organization is suspended or not.
+                    description: (Boolean) Whether an Organization is suspended or
+                      not.
                     type: boolean
                   updatedAt:
-                    description: |-
-                      (String) The date and time when the resource was updated in RFC3339 format.
-                      The date and time when the resource was updated in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
+                    description: (String) The date and time when the resource was
+                      updated in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
                     type: string
                 type: object
               conditions:

--- a/package/crds/cloudfoundry.crossplane.io_orgmembers.yaml
+++ b/package/crds/cloudfoundry.crossplane.io_orgmembers.yaml
@@ -55,7 +55,6 @@ spec:
           metadata:
             type: object
           spec:
-            description: OrgMembersSpec defines the desired state of OrgMembers
             properties:
               deletionPolicy:
                 default: Delete
@@ -72,47 +71,47 @@ spec:
                 - Delete
                 type: string
               forProvider:
-                description: OrgMembersParameters encapsulate role assignments to
-                  CloudFoundry Organizations
                 properties:
                   enforcementPolicy:
                     default: Lax
-                    description: Set to `Lax` to enforce that the role is assigned
-                      to AT LEAST those members as defined in this CR. Set to `Strict`
-                      to enforce that the role is assigned to EXACT those members
-                      as defined in CR and any other members will be removed. Defaults
-                      to `Lax`.
+                    description: (String) Set to `Lax` to enforce that the role is
+                      assigned to AT LEAST those members as defined in this CR. Set
+                      to `Strict` to enforce that the role is assigned to EXACTLY
+                      those members as defined in this CR and any other members will
+                      be removed. Defaults to `Lax`.
                     enum:
                     - Lax
                     - Strict
                     type: string
                   members:
-                    description: List of members (usernames) to assign as org members
-                      with the specified role type. Defaults to empty list.
+                    description: (List of Attributes) List of members (usernames)
+                      to assign as org members with the specified role type. Defaults
+                      to empty list.
                     items:
-                      description: Member identifies a user by name and origin
+                      description: Member identifies a user by name and origin.
                       properties:
                         origin:
                           default: sap.ids
-                          description: Origin picks the IDP
+                          description: (String) Origin selects the identity provider.
+                            Defaults to "sap.ids".
                           type: string
                         username:
-                          description: Username at the identity provider
+                          description: (String) Username at the identity provider.
                           type: string
                       required:
                       - username
                       type: object
                     type: array
                   org:
-                    description: (String) The guid of the organization
+                    description: (String) The GUID of the organization.
                     type: string
                   orgName:
-                    description: The name of the Cloud Foundry organization containing
-                      the space.
+                    description: (String) The name of the Cloud Foundry organization
+                      containing the space.
                     type: string
                   orgRef:
-                    description: Reference to an `Org` CR to retrieve the external
-                      GUID of the organization.
+                    description: (Attributes) Reference to an `Org` CR to retrieve
+                      the external GUID of the organization.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -146,8 +145,8 @@ spec:
                     - name
                     type: object
                   orgSelector:
-                    description: Selector to an `Org` CR to retrieve the external
-                      GUID of the Organization.
+                    description: (Attributes) Selector to an `Org` CR to retrieve
+                      the external GUID of the organization.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -187,8 +186,8 @@ spec:
                         type: object
                     type: object
                   roleType:
-                    description: Org role type to assign to members; see valid role
-                      types https://v3-apidocs.cloudfoundry.org/version/3.127.0/index.html#valid-role-types
+                    description: (String) Org role type to assign to members; see
+                      valid role types https://v3-apidocs.cloudfoundry.org/version/3.127.0/index.html#valid-role-types
                     enum:
                     - User
                     - Auditor
@@ -371,16 +370,16 @@ spec:
             - forProvider
             type: object
           status:
-            description: OrgMembersStatus defines the observed state of OrgMembers.
             properties:
               atProvider:
-                description: RoleAssignments maps members to roles
+                description: (Attributes) The assigned roles for the organization
+                  members.
                 properties:
                   assignedRoles:
                     additionalProperties:
                       type: string
-                    description: '`AssignedRoles` maps member to GUIDs of the assigned
-                      Role objects.'
+                    description: (Map of String) `assignedRoles` maps a member to
+                      the GUID of the assigned Role object.
                     type: object
                 type: object
               conditions:

--- a/package/crds/cloudfoundry.crossplane.io_orgquotas.yaml
+++ b/package/crds/cloudfoundry.crossplane.io_orgquotas.yaml
@@ -74,72 +74,53 @@ spec:
               forProvider:
                 properties:
                   allowPaidServicePlans:
-                    description: |-
-                      free service plans. Does not control plan visibility. When false, non-free service plans may be visible in the marketplace but instances can not be provisioned.
-                      Determines whether users can provision instances of non-free service plans. Does not control plan visibility. When false, non-free service plans may be visible in the marketplace but instances can not be provisioned.
+                    description: (Boolean) Determines whether users can provision
+                      instances of non-free service plans. Does not control plan visibility.
+                      When false, non-free service plans may be visible in the marketplace
+                      but instances cannot be provisioned.
                     type: boolean
                   instanceMemory:
-                    description: |-
-                      (Number) Maximum memory per application instance.
-                      Maximum memory per application instance.
+                    description: (Number) Maximum memory per application instance.
                     type: number
                   name:
-                    description: |-
-                      (String) The name you use to identify the quota or plan in Cloud Foundry
-                      The name you use to identify the quota or plan in Cloud Foundry
+                    description: (String) The name you use to identify the quota or
+                      plan in Cloud Foundry.
                     type: string
                   orgs:
-                    description: |-
-                      (Set of String) Set of Org GUIDs to which this org quota would be assigned.
-                      Set of Org GUIDs to which this org quota would be assigned.
+                    description: (Set of String) Set of Org GUIDs to which this org
+                      quota would be assigned.
                     items:
                       type: string
                     type: array
                     x-kubernetes-list-type: set
                   totalAppInstances:
-                    description: |-
-                      (Number) Maximum app instances allowed.
-                      Maximum app instances allowed.
+                    description: (Number) Maximum app instances allowed.
                     type: number
                   totalAppLogRateLimit:
-                    description: |-
-                      (Number) Maximum log rate allowed for all the started processes and running tasks in bytes/second.
-                      Maximum log rate allowed for all the started processes and running tasks in bytes/second.
+                    description: (Number) Maximum log rate allowed for all the started
+                      processes and running tasks in bytes/second.
                     type: number
                   totalAppTasks:
-                    description: |-
-                      (Number) Maximum tasks allowed per app.
-                      Maximum tasks allowed per app.
+                    description: (Number) Maximum tasks allowed per app.
                     type: number
                   totalMemory:
-                    description: |-
-                      (Number) Maximum memory usage allowed.
-                      Maximum memory usage allowed.
+                    description: (Number) Maximum memory usage allowed.
                     type: number
                   totalPrivateDomains:
-                    description: |-
-                      (Number) Maximum number of private domains allowed to be created within the Org.
-                      Maximum number of private domains allowed to be created within the Org.
+                    description: (Number) Maximum number of private domains allowed
+                      to be created within the Org.
                     type: number
                   totalRoutePorts:
-                    description: |-
-                      (Number) Maximum routes with reserved ports.
-                      Maximum routes with reserved ports.
+                    description: (Number) Maximum routes with reserved ports.
                     type: number
                   totalRoutes:
-                    description: |-
-                      (Number) Maximum routes allowed.
-                      Maximum routes allowed.
+                    description: (Number) Maximum routes allowed.
                     type: number
                   totalServiceKeys:
-                    description: |-
-                      (Number) Maximum service keys allowed.
-                      Maximum service keys allowed.
+                    description: (Number) Maximum service keys allowed.
                     type: number
                   totalServices:
-                    description: |-
-                      (Number) Maximum services allowed.
-                      Maximum services allowed.
+                    description: (Number) Maximum services allowed.
                     type: number
                 type: object
               initProvider:
@@ -156,72 +137,53 @@ spec:
                   autoscaler.
                 properties:
                   allowPaidServicePlans:
-                    description: |-
-                      free service plans. Does not control plan visibility. When false, non-free service plans may be visible in the marketplace but instances can not be provisioned.
-                      Determines whether users can provision instances of non-free service plans. Does not control plan visibility. When false, non-free service plans may be visible in the marketplace but instances can not be provisioned.
+                    description: (Boolean) Determines whether users can provision
+                      instances of non-free service plans. Does not control plan visibility.
+                      When false, non-free service plans may be visible in the marketplace
+                      but instances cannot be provisioned.
                     type: boolean
                   instanceMemory:
-                    description: |-
-                      (Number) Maximum memory per application instance.
-                      Maximum memory per application instance.
+                    description: (Number) Maximum memory per application instance.
                     type: number
                   name:
-                    description: |-
-                      (String) The name you use to identify the quota or plan in Cloud Foundry
-                      The name you use to identify the quota or plan in Cloud Foundry
+                    description: (String) The name you use to identify the quota or
+                      plan in Cloud Foundry.
                     type: string
                   orgs:
-                    description: |-
-                      (Set of String) Set of Org GUIDs to which this org quota would be assigned.
-                      Set of Org GUIDs to which this org quota would be assigned.
+                    description: (Set of String) Set of Org GUIDs to which this org
+                      quota would be assigned.
                     items:
                       type: string
                     type: array
                     x-kubernetes-list-type: set
                   totalAppInstances:
-                    description: |-
-                      (Number) Maximum app instances allowed.
-                      Maximum app instances allowed.
+                    description: (Number) Maximum app instances allowed.
                     type: number
                   totalAppLogRateLimit:
-                    description: |-
-                      (Number) Maximum log rate allowed for all the started processes and running tasks in bytes/second.
-                      Maximum log rate allowed for all the started processes and running tasks in bytes/second.
+                    description: (Number) Maximum log rate allowed for all the started
+                      processes and running tasks in bytes/second.
                     type: number
                   totalAppTasks:
-                    description: |-
-                      (Number) Maximum tasks allowed per app.
-                      Maximum tasks allowed per app.
+                    description: (Number) Maximum tasks allowed per app.
                     type: number
                   totalMemory:
-                    description: |-
-                      (Number) Maximum memory usage allowed.
-                      Maximum memory usage allowed.
+                    description: (Number) Maximum memory usage allowed.
                     type: number
                   totalPrivateDomains:
-                    description: |-
-                      (Number) Maximum number of private domains allowed to be created within the Org.
-                      Maximum number of private domains allowed to be created within the Org.
+                    description: (Number) Maximum number of private domains allowed
+                      to be created within the Org.
                     type: number
                   totalRoutePorts:
-                    description: |-
-                      (Number) Maximum routes with reserved ports.
-                      Maximum routes with reserved ports.
+                    description: (Number) Maximum routes with reserved ports.
                     type: number
                   totalRoutes:
-                    description: |-
-                      (Number) Maximum routes allowed.
-                      Maximum routes allowed.
+                    description: (Number) Maximum routes allowed.
                     type: number
                   totalServiceKeys:
-                    description: |-
-                      (Number) Maximum service keys allowed.
-                      Maximum service keys allowed.
+                    description: (Number) Maximum service keys allowed.
                     type: number
                   totalServices:
-                    description: |-
-                      (Number) Maximum services allowed.
-                      Maximum services allowed.
+                    description: (Number) Maximum services allowed.
                     type: number
                 type: object
               managementPolicies:
@@ -406,85 +368,64 @@ spec:
               atProvider:
                 properties:
                   allowPaidServicePlans:
-                    description: |-
-                      free service plans. Does not control plan visibility. When false, non-free service plans may be visible in the marketplace but instances can not be provisioned.
-                      Determines whether users can provision instances of non-free service plans. Does not control plan visibility. When false, non-free service plans may be visible in the marketplace but instances can not be provisioned.
+                    description: (Boolean) Determines whether users can provision
+                      instances of non-free service plans. Does not control plan visibility.
+                      When false, non-free service plans may be visible in the marketplace
+                      but instances cannot be provisioned.
                     type: boolean
                   createdAt:
-                    description: |-
-                      (String) The date and time when the resource was created in RFC3339 format.
-                      The date and time when the resource was created in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
+                    description: (String) The date and time when the resource was
+                      created in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
                     type: string
                   id:
                     description: (String) The GUID of the object.
                     type: string
                   instanceMemory:
-                    description: |-
-                      (Number) Maximum memory per application instance.
-                      Maximum memory per application instance.
+                    description: (Number) Maximum memory per application instance.
                     type: number
                   name:
-                    description: |-
-                      (String) The name you use to identify the quota or plan in Cloud Foundry
-                      The name you use to identify the quota or plan in Cloud Foundry
+                    description: (String) The name you use to identify the quota or
+                      plan in Cloud Foundry.
                     type: string
                   orgs:
-                    description: |-
-                      (Set of String) Set of Org GUIDs to which this org quota would be assigned.
-                      Set of Org GUIDs to which this org quota would be assigned.
+                    description: (Set of String) Set of Org GUIDs to which this org
+                      quota would be assigned.
                     items:
                       type: string
                     type: array
                     x-kubernetes-list-type: set
                   totalAppInstances:
-                    description: |-
-                      (Number) Maximum app instances allowed.
-                      Maximum app instances allowed.
+                    description: (Number) Maximum app instances allowed.
                     type: number
                   totalAppLogRateLimit:
-                    description: |-
-                      (Number) Maximum log rate allowed for all the started processes and running tasks in bytes/second.
-                      Maximum log rate allowed for all the started processes and running tasks in bytes/second.
+                    description: (Number) Maximum log rate allowed for all the started
+                      processes and running tasks in bytes/second.
                     type: number
                   totalAppTasks:
-                    description: |-
-                      (Number) Maximum tasks allowed per app.
-                      Maximum tasks allowed per app.
+                    description: (Number) Maximum tasks allowed per app.
                     type: number
                   totalMemory:
-                    description: |-
-                      (Number) Maximum memory usage allowed.
-                      Maximum memory usage allowed.
+                    description: (Number) Maximum memory usage allowed.
                     type: number
                   totalPrivateDomains:
-                    description: |-
-                      (Number) Maximum number of private domains allowed to be created within the Org.
-                      Maximum number of private domains allowed to be created within the Org.
+                    description: (Number) Maximum number of private domains allowed
+                      to be created within the Org.
                     type: number
                   totalRoutePorts:
-                    description: |-
-                      (Number) Maximum routes with reserved ports.
-                      Maximum routes with reserved ports.
+                    description: (Number) Maximum routes with reserved ports.
                     type: number
                   totalRoutes:
-                    description: |-
-                      (Number) Maximum routes allowed.
-                      Maximum routes allowed.
+                    description: (Number) Maximum routes allowed.
                     type: number
                   totalServiceKeys:
-                    description: |-
-                      (Number) Maximum service keys allowed.
-                      Maximum service keys allowed.
+                    description: (Number) Maximum service keys allowed.
                     type: number
                   totalServices:
-                    description: |-
-                      (Number) Maximum services allowed.
-                      Maximum services allowed.
+                    description: (Number) Maximum services allowed.
                     type: number
                   updatedAt:
-                    description: |-
-                      (String) The date and time when the resource was updated in RFC3339 format.
-                      The date and time when the resource was updated in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
+                    description: (String) The date and time when the resource was
+                      updated in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
                     type: string
                 type: object
               conditions:

--- a/package/crds/cloudfoundry.crossplane.io_orgroles.yaml
+++ b/package/crds/cloudfoundry.crossplane.io_orgroles.yaml
@@ -75,15 +75,15 @@ spec:
               forProvider:
                 properties:
                   org:
-                    description: (String) The guid of the organization
+                    description: (String) The GUID of the organization.
                     type: string
                   orgName:
-                    description: The name of the Cloud Foundry organization containing
-                      the space.
+                    description: (String) The name of the Cloud Foundry organization
+                      containing the space.
                     type: string
                   orgRef:
-                    description: Reference to an `Org` CR to retrieve the external
-                      GUID of the organization.
+                    description: (Attributes) Reference to an `Org` CR to retrieve
+                      the external GUID of the organization.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -117,8 +117,8 @@ spec:
                     - name
                     type: object
                   orgSelector:
-                    description: Selector to an `Org` CR to retrieve the external
-                      GUID of the Organization.
+                    description: (Attributes) Selector to an `Org` CR to retrieve
+                      the external GUID of the organization.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -158,14 +158,10 @@ spec:
                         type: object
                     type: object
                   origin:
-                    description: |-
-                      (String) The identity provider for the UAA user
-                      The identity provider for the UAA user
+                    description: (String) The identity provider for the UAA user.
                     type: string
                   type:
-                    description: |-
-                      (String) OrgRole type; see Valid role types
-                      OrgRole type; see [Valid role types](https://v3-apidocs.cloudfoundry.org/version/3.154.0/index.html#valid-role-types)
+                    description: (String) The org role type; see [Valid role types](https://v3-apidocs.cloudfoundry.org/version/3.154.0/index.html#valid-role-types).
                     enum:
                     - User
                     - Auditor
@@ -177,9 +173,8 @@ spec:
                     - BillingManagers
                     type: string
                   username:
-                    description: |-
-                      (String) The username of the cloudfoundry user to assign the role with
-                      The username of the cloudfoundry user to assign the role with
+                    description: (String) The username of the Cloud Foundry user to
+                      assign the role to.
                     type: string
                 type: object
               managementPolicies:
@@ -355,37 +350,29 @@ spec:
               atProvider:
                 properties:
                   createdAt:
-                    description: |-
-                      (String) The date and time when the resource was created in RFC3339 format.
-                      The date and time when the resource was created in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
+                    description: (String) The date and time when the resource was
+                      created in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
                     type: string
                   id:
                     description: (String) The GUID of the object.
                     type: string
                   origin:
-                    description: |-
-                      (String) The identity provider for the UAA user
-                      The identity provider for the UAA user
+                    description: (String) The identity provider for the UAA user.
                     type: string
                   type:
-                    description: |-
-                      (String) OrgRole type; see Valid role types
-                      OrgRole type; see [Valid role types](https://v3-apidocs.cloudfoundry.org/version/3.154.0/index.html#valid-role-types)
+                    description: (String) The org role type; see [Valid role types](https://v3-apidocs.cloudfoundry.org/version/3.154.0/index.html#valid-role-types).
                     type: string
                   updatedAt:
-                    description: |-
-                      (String) The date and time when the resource was updated in RFC3339 format.
-                      The date and time when the resource was updated in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
+                    description: (String) The date and time when the resource was
+                      updated in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
                     type: string
                   user:
-                    description: |-
-                      (String) The guid of the cloudfoundry user to assign the role with
-                      The guid of the cloudfoundry user to assign the role with
+                    description: (String) The GUID of the Cloud Foundry user to assign
+                      the role to.
                     type: string
                   username:
-                    description: |-
-                      (String) The username of the cloudfoundry user to assign the role with
-                      The username of the cloudfoundry user to assign the role with
+                    description: (String) The username of the Cloud Foundry user to
+                      assign the role to.
                     type: string
                 type: object
               conditions:

--- a/package/crds/cloudfoundry.crossplane.io_routes.yaml
+++ b/package/crds/cloudfoundry.crossplane.io_routes.yaml
@@ -72,22 +72,21 @@ spec:
                 - Delete
                 type: string
               forProvider:
-                description: RouteParameters parameters for Routes
                 properties:
                   domain:
-                    description: The `guid` of the Cloud Foundry domain. This field
-                      is typically populated using references specified in `domainRef`,
+                    description: (String) The GUID of the Cloud Foundry domain. This
+                      field is typically populated using references specified in `domainRef`,
                       `domainSelector`, or `domainName`.
                     type: string
                   domainName:
-                    description: The name of the Cloud Foundry domain to lookup the
-                      `guid` of the Domain. Use `domainName` only when the referenced
-                      Domain is not managed by Crossplane.
+                    description: (String) The name of the Cloud Foundry domain to
+                      lookup the GUID of the domain. Use `domainName` only when the
+                      referenced domain is not managed by Crossplane.
                     type: string
                   domainRef:
-                    description: Reference to a `Domain` CR to lookup the `guid` of
-                      the Cloud Foundry domain. Preferred if the reference domain
-                      is managed by Crossplane.
+                    description: (Attributes) Reference to a `domain` CR to lookup
+                      the GUID of the Cloud Foundry domain. Preferred if the referenced
+                      domain is managed by Crossplane.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -121,9 +120,9 @@ spec:
                     - name
                     type: object
                   domainSelector:
-                    description: Selector for a `Domain` CR to lookup the `guid` of
-                      the Cloud Foundry domain. Preferred if the reference domain
-                      is managed by Crossplane.
+                    description: (Attributes) Selector for a `domain` CR to lookup
+                      the GUID of the Cloud Foundry domain. Preferred if the referenced
+                      domain is managed by Crossplane.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -163,42 +162,42 @@ spec:
                         type: object
                     type: object
                   host:
-                    description: The application's host name. This is required for
+                    description: (String) The application's host name. Required for
                       shared domains.
                     type: string
                   options:
-                    description: The route options
+                    description: (Attributes) The route options.
                     properties:
                       loadbalancing:
-                        description: The load-balancer associated with this route.
-                          Valid values are ‘round-robin’ and ‘least-connections’
+                        description: (String) The load balancer associated with this
+                          route. Valid values are `round-robin` and `least-connections`.
                         type: string
                     type: object
                   orgName:
-                    description: The name of the Cloud Foundry organization containing
-                      the space.
+                    description: (String) The name of the Cloud Foundry organization
+                      containing the space.
                     type: string
                   path:
-                    description: A path for an HTTP route.
+                    description: (String) A path for an HTTP route.
                     type: string
                   port:
-                    description: The port to associate with the route for a TCP route.
-                      Conflicts with random_port.
+                    description: (Integer) The port to associate with the route for
+                      a TCP route. Conflicts with `random_port`.
                     type: integer
                   space:
-                    description: The `guid` of the Cloud Foundry space. This field
-                      is typically populated using references specified in `spaceRef`,
+                    description: (String) The GUID of the Cloud Foundry space. This
+                      field is typically populated using references specified in `spaceRef`,
                       `spaceSelector`, or `spaceName`.
                     type: string
                   spaceName:
-                    description: The name of the Cloud Foundry space to lookup the
-                      `guid` of the Space. Use `spaceName` only when the reference
-                      Space is not managed by Crossplane.
+                    description: (String) The name of the Cloud Foundry space to lookup
+                      the GUID of the space. Use `spaceName` only when the referenced
+                      space is not managed by Crossplane.
                     type: string
                   spaceRef:
-                    description: Reference to a `Space` CR to lookup the `guid` of
-                      the Cloud Foundry space. Preferred if the reference space is
-                      managed by Crossplane.
+                    description: (Attributes) Reference to a `Space` CR to lookup
+                      the GUID of the Cloud Foundry space. Preferred if the referenced
+                      space is managed by Crossplane.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -232,9 +231,9 @@ spec:
                     - name
                     type: object
                   spaceSelector:
-                    description: Selector for a `Space` CR to lookup the `guid` of
-                      the Cloud Foundry space. Preferred if the reference space is
-                      managed by Crossplane.
+                    description: (Attributes) Selector for a `Space` CR to lookup
+                      the GUID of the Cloud Foundry space. Preferred if the referenced
+                      space is managed by Crossplane.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -445,69 +444,70 @@ spec:
             description: RouteStatus defines the observed state of Route.
             properties:
               atProvider:
-                description: RouteObservation observations for routes
                 properties:
                   createdAt:
-                    description: The date and time when the resource was created in
-                      [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
+                    description: (String) The date and time when the resource was
+                      created in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
                     type: string
                   destinations:
-                    description: One or more route mapping(s) that will map this route
-                      to application(s). Can be repeated multiple times to load balance
+                    description: (List of Attributes) One or more route mappings that
+                      map this route to applications. Can be repeated to load balance
                       route traffic among multiple applications.
                     items:
-                      description: RouteDestination describes a route destinations
                       properties:
                         app:
-                          description: The ID of the application to map this route
+                          description: (Attributes) The application to map this route
                             to.
                           properties:
                             guid:
+                              description: (String) The application GUID.
                               type: string
                             port:
-                              description: Port on the destination application
+                              description: (Integer) Port on the destination application.
                               type: integer
                             process:
-                              description: The process type of the destination.
+                              description: (String) The process type of the destination.
                               type: string
                             protocol:
+                              description: (String) The protocol for the destination
+                                application.
                               type: string
                           type: object
                         guid:
-                          description: The destination GUID
+                          description: (String) The destination GUID.
                           type: string
                         port:
-                          description: The port to associate with the route for a
-                            TCP route. Conflicts with random_port.
+                          description: (Integer) The port to associate with the route
+                            for a TCP route. Conflicts with `random_port`.
                           type: integer
                       type: object
                     type: array
                   guid:
-                    description: The GUID of the Cloud Foundry resource
+                    description: (String) The GUID of the Cloud Foundry resource.
                     type: string
                   host:
-                    description: The host name of the route
+                    description: (String) The host name of the route.
                     type: string
                   options:
-                    description: The route options
+                    description: (Attributes) The route options.
                     properties:
                       loadbalancing:
-                        description: The load-balancer associated with this route.
-                          Valid values are ‘round-robin’ and ‘least-connections’
+                        description: (String) The load balancer associated with this
+                          route. Valid values are `round-robin` and `least-connections`.
                         type: string
                     type: object
                   path:
-                    description: The path of the route
+                    description: (String) The path of the route.
                     type: string
                   protocol:
-                    description: Protocol of the route
+                    description: (String) The protocol of the route.
                     type: string
                   updatedAt:
-                    description: The date and time when the resource was updated in
-                      [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
+                    description: (String) The date and time when the resource was
+                      updated in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
                     type: string
                   url:
-                    description: The URL of the route
+                    description: (String) The URL of the route.
                     type: string
                 type: object
               conditions:

--- a/package/crds/cloudfoundry.crossplane.io_servicecredentialbindings.yaml
+++ b/package/crds/cloudfoundry.crossplane.io_servicecredentialbindings.yaml
@@ -55,14 +55,12 @@ spec:
           metadata:
             type: object
           spec:
-            description: ServiceCredentialBindingSpec defines the desired state of
-              ServiceCredentialBinding
             properties:
               connectionDetailsAsJSON:
                 default: false
-                description: True to write connectionDetails as single key-value in
-                  a secret rather than a map. The key is the metadata.name of the
-                  service credential binding CR itself.
+                description: (Boolean) True to write `connectionDetails` as a single
+                  key-value in a secret rather than a map. The key is the metadata.name
+                  of the service credential binding CR itself.
                 type: boolean
               deletionPolicy:
                 default: Delete
@@ -79,15 +77,13 @@ spec:
                 - Delete
                 type: string
               forProvider:
-                description: ServiceCredentialBindingParameters define the desired
-                  state of the forProvider field of ServiceCredentialBinding
                 properties:
                   app:
-                    description: The ID of an App  that should be bound to. Required
-                      if Type is "app".
+                    description: (String) The ID of an app that should be bound to.
+                      Required if `type` is "app".
                     type: string
                   appRef:
-                    description: Reference to an App CR to populate app.
+                    description: (Attributes) Reference to an app CR to populate `app`.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -121,7 +117,7 @@ spec:
                     - name
                     type: object
                   appSelector:
-                    description: Selector for an App CR to populate app.
+                    description: (Attributes) Selector for an app CR to populate `app`.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -162,23 +158,25 @@ spec:
                     type: object
                   connectionDetailsAsJSON:
                     default: false
-                    description: (Deprecated) True to write connectionDetails as single
-                      key-value in a secret rather than a map. The key is the metadata.name
-                      of the service credential binding CR itself. This is deprecated
-                      in favor of the spec.connectionDetailsAsJSON field.
+                    description: (Boolean, Deprecated) True to write `connectionDetails`
+                      as a single key-value in a secret rather than a map. The key
+                      is the metadata.name of the service credential binding CR itself.
+                      This is deprecated in favor of the `spec.connectionDetailsAsJSON`
+                      field.
                     type: boolean
                   name:
-                    description: The name of the Service Key in Cloud Foundry. Required
-                      if Type is "key".
+                    description: (String) The name of the service credential binding
+                      in Cloud Foundry. Required if `type` is "key".
                     type: string
                   parameters:
-                    description: An optional JSON object to pass parameters to the
-                      service broker .
+                    description: (Attributes) An optional JSON object to pass `parameters`
+                      to the service broker.
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   paramsSecretRef:
-                    description: Use a reference to a secret to pass parameters to
-                      the service broker. Ignored if parameters is set.
+                    description: (Attributes) Use a reference to a secret to pass
+                      `parameters` to the service broker. Ignored if `parameters`
+                      is set.
                     properties:
                       name:
                         description: Name of the secret.
@@ -191,12 +189,12 @@ spec:
                     - namespace
                     type: object
                   serviceInstance:
-                    description: The ID of the Service Instance the key should be
-                      associated with.
+                    description: (String) The ID of the service instance the binding
+                      should be associated with.
                     type: string
                   serviceInstanceRef:
-                    description: Reference to a ManagedServiceInstance to populate
-                      serviceInstance.
+                    description: (Attributes) Reference to a managed service instance
+                      to populate `serviceInstance`.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -230,8 +228,8 @@ spec:
                     - name
                     type: object
                   serviceInstanceSelector:
-                    description: Selector for a ManagedServiceInstance to populate
-                      serviceInstance.
+                    description: (Attributes) Selector for a managed service instance
+                      to populate `serviceInstance`.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -272,8 +270,8 @@ spec:
                     type: object
                   type:
                     default: key
-                    description: The type of the Service Key in Cloud Foundry. Either
-                      "key" or "app".
+                    description: (String) The type of the service credential binding
+                      in Cloud Foundry. Either "key" or "app".
                     enum:
                     - key
                     - app
@@ -447,22 +445,18 @@ spec:
             - forProvider
             type: object
           status:
-            description: ServiceCredentialBindingStatus defines the observed state
-              of ServiceCredentialBinding.
             properties:
               atProvider:
-                description: ServiceCredentialBindingObservation defines the observed
-                  state of ServiceCredentialBinding
                 properties:
                   createdAt:
-                    description: The date and time when the resource was created in
-                      [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
+                    description: (String) The date and time when the resource was
+                      created in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
                     type: string
                   guid:
-                    description: The GUID of the Cloud Foundry resource
+                    description: (String) The GUID of the Cloud Foundry resource.
                     type: string
                   lastOperation:
-                    description: LastOperation describes the last operation performed
+                    description: (Attributes) The details of the last operation performed
                       on the service credential binding.
                     properties:
                       createdAt:
@@ -485,8 +479,8 @@ spec:
                         type: string
                     type: object
                   updatedAt:
-                    description: The date and time when the resource was updated in
-                      [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
+                    description: (String) The date and time when the resource was
+                      updated in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
                     type: string
                 type: object
               conditions:

--- a/package/crds/cloudfoundry.crossplane.io_serviceinstances.yaml
+++ b/package/crds/cloudfoundry.crossplane.io_serviceinstances.yaml
@@ -35,7 +35,7 @@ spec:
     schema:
       openAPIV3Schema:
         description: 'ServiceInstance is the Schema for the ServiceInstances API.
-          Creates a service instance in a cloudfoundry space. Further documentation:
+          Creates a service instance in a Cloud Foundry space. Further documentation:
           https://docs.cloudfoundry.org/devguide/services'
         properties:
           apiVersion:
@@ -74,34 +74,29 @@ spec:
                 type: string
               enableParameterDriftDetection:
                 default: false
-                description: Enable drift detection for configuration parameters of
-                  managed service instance. Default is false.
+                description: (Boolean) Enable drift detection for configuration parameters
+                  of managed service instance. Default is false.
                 type: boolean
               forProvider:
-                description: ServiceInstanceParameters define the desired state of
-                  a Cloud Foundry service instance.
                 properties:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: The annotations associated with Cloud Foundry resources.
-                      Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
+                    description: (Map of String) The annotations associated with Cloud
+                      Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
                     type: object
                     x-kubernetes-map-type: granular
                   credentials:
                     description: |-
-                      Arbitrary credentials as K8S runtime.RawExtension object, delivered to applications via VCAP_SERVICES environment variables.Applicable for user-provided service instance type.
-
-
-                      The Credentials field is NOT secret or secured in any way and should
-                      NEVER be used to hold sensitive information. To set parameters that
-                      contain secret information, you should ALWAYS store that information
-                      in a Secret and use the `credentialsSecretRef` field.
+                      (Attributes) Arbitrary credentials as K8S runtime.RawExtension object, delivered to applications via VCAP_SERVICES environment variables.
+                      The `credentials` field is NOT secret or secured in any way and should NEVER be used to hold sensitive information.
+                      To set parameters that contain secret information, you should ALWAYS store that information in a Secret and use the `credentialsSecretRef` field.
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   credentialsSecretRef:
-                    description: Same as `Credentials`, supplied as a Secret reference.
-                      Ignored if `credentials` or `jsonCredentials` is set.
+                    description: (Attributes) Same as `credentials`, supplied as a
+                      Secret reference. Ignored if `credentials` or `jsonCredentials`
+                      is set.
                     properties:
                       name:
                         description: Name of the secret.
@@ -114,45 +109,42 @@ spec:
                     - namespace
                     type: object
                   jsonCredentials:
-                    description: Same as `credentials`, supplied as arbitrary JSON
-                      string. Ignored if `credentials` is set.
+                    description: (String) Same as `credentials`, supplied as arbitrary
+                      JSON string. Ignored if `credentials` is set.
                     type: string
                   jsonParams:
-                    description: Same as `parameters`, supplied as arbitrary JSON
-                      string. Ignored if `parameters` is set.
+                    description: (String) Same as `parameters`, supplied as arbitrary
+                      JSON string. Ignored if `parameters` is set.
                     type: string
                   maintenanceInfo:
-                    description: MaintenanceInfo describes the version of the service
-                      instance
+                    description: (Attributes) Information about the version of this
+                      service instance; only shown when `type` is `managed`.
                     properties:
                       description:
-                        description: (String) A description of the last operation
+                        description: (String) A description of the last operation.
                         type: string
                       version:
-                        description: (String) The version of the service instance
+                        description: (String) The version of the service instance.
                         type: string
                     type: object
                   name:
-                    description: The name of the service instance
+                    description: (String) The name of the service instance
                     type: string
                   orgName:
-                    description: The name of the Cloud Foundry organization containing
-                      the space.
+                    description: (String) The name of the Cloud Foundry organization
+                      containing the space.
                     type: string
                   parameters:
                     description: |-
-                      Configuration parameters for the managed service instance, supplied as K8S runtime.RawExtension object
-
-
-                      The `parameters` field is NOT secret or secured in any way and should
-                      NEVER be used to hold sensitive information. To set parameters that
-                      contain secret information, you should ALWAYS store that information
-                      in a Secret and use the `paramsSecretRef` field.
+                      (Attributes) Configuration parameters for the managed service instance, supplied as a K8S runtime.RawExtension object.
+                      The `parameters` field is NOT secret or secured in any way and should NEVER be used to hold sensitive information.
+                      To set parameters that contain secret information, you should ALWAYS store that information in a Secret and use the `paramsSecretRef` field.
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   paramsSecretRef:
-                    description: Same as `parameters`, supplied as a Secret reference.
-                      Ignored if `parameters` or `jsonParams` is set.
+                    description: (Attributes) Same as `parameters`, supplied as a
+                      Secret reference. Ignored if `parameters` or `jsonParams` is
+                      set.
                     properties:
                       name:
                         description: Name of the secret.
@@ -165,38 +157,38 @@ spec:
                     - namespace
                     type: object
                   routeServiceUrl:
-                    description: URL to which requests for bound routes will be forwarded;
-                      only shown when type is user-provided.
+                    description: (String) URL to which requests for bound routes will
+                      be forwarded; only shown when `type` is `user-provided`.
                     type: string
                   servicePlan:
-                    description: |-
-                      (String) The ID of the service plan from which to create the service instance
-                      The ID of the service plan from which to create the service instance
+                    description: (Attributes) Reference to the service plan for the
+                      managed service instance.
                     properties:
                       id:
-                        description: The ID of the service plan
+                        description: (String) The ID of the service plan from which
+                          to create the service instance.
                         type: string
                       offering:
-                        description: The name of service offering
+                        description: (String) The name of the plan offering.
                         type: string
                       plan:
-                        description: The name of service plan
+                        description: (String) The name of the service plan.
                         type: string
                     type: object
                   space:
-                    description: The `guid` of the Cloud Foundry space. This field
-                      is typically populated using references specified in `spaceRef`,
+                    description: (String) The GUID of the Cloud Foundry space. This
+                      field is typically populated using references specified in `spaceRef`,
                       `spaceSelector`, or `spaceName`.
                     type: string
                   spaceName:
-                    description: The name of the Cloud Foundry space to lookup the
-                      `guid` of the Space. Use `spaceName` only when the reference
-                      Space is not managed by Crossplane.
+                    description: (String) The name of the Cloud Foundry space to lookup
+                      the GUID of the space. Use `spaceName` only when the referenced
+                      space is not managed by Crossplane.
                     type: string
                   spaceRef:
-                    description: Reference to a `Space` CR to lookup the `guid` of
-                      the Cloud Foundry space. Preferred if the reference space is
-                      managed by Crossplane.
+                    description: (Attributes) Reference to a `Space` CR to lookup
+                      the GUID of the Cloud Foundry space. Preferred if the referenced
+                      space is managed by Crossplane.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -230,9 +222,9 @@ spec:
                     - name
                     type: object
                   spaceSelector:
-                    description: Selector for a `Space` CR to lookup the `guid` of
-                      the Cloud Foundry space. Preferred if the reference space is
-                      managed by Crossplane.
+                    description: (Attributes) Selector for a `Space` CR to lookup
+                      the GUID of the Cloud Foundry space. Preferred if the referenced
+                      space is managed by Crossplane.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -272,35 +264,35 @@ spec:
                         type: object
                     type: object
                   syslogDrainUrl:
-                    description: URL to which logs for bound applications will be
-                      streamed; only shown when type is user-provided.
+                    description: (String) URL to which logs for bound applications
+                      will be streamed; only shown when `type` is `user-provided`.
                     type: string
                   tags:
-                    description: List of tags used by apps to identify service instances.
-                      They are shown in the app VCAP_SERVICES env.
+                    description: (List of String) List of tags used by apps to identify
+                      service instances. They are shown in the app VCAP_SERVICES env.
                     items:
                       type: string
                     type: array
                   timeouts:
-                    description: Timeouts for the service instance operations
+                    description: (Attributes) Timeouts for the service instance operations.
                     properties:
                       create:
                         description: (String) Timeout for creating the service instance.
-                          Default is 40 minutes
+                          Default is 40 minutes.
                         type: string
                       delete:
                         description: (String) Timeout for deleting the service instance.
-                          Default is 40 minutes
+                          Default is 40 minutes.
                         type: string
                       update:
                         description: (String) Timeout for updating the service instance.
-                          Default is 40 minutes
+                          Default is 40 minutes.
                         type: string
                     type: object
                   type:
                     default: managed
-                    description: Type of the service instance. Either managed or user-provided.
-                      Default is managed.
+                    description: (String) Type of the service instance. Either managed
+                      or user-provided. Default is managed.
                     enum:
                     - managed
                     - user-provided
@@ -479,49 +471,44 @@ spec:
             description: ServiceInstanceStatus defines the observed state of ServiceInstance
             properties:
               atProvider:
-                description: ServiceInstanceObservation records the observed state
-                  of a Cloud Foundry service instance.
                 properties:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: |-
-                      (Map of String) The annotations associated with Cloud Foundry resources. Add as described here.
-                      The annotations associated with Cloud Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
+                    description: (Map of String) The annotations associated with Cloud
+                      Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
                     type: object
                     x-kubernetes-map-type: granular
                   createdAt:
-                    description: |-
-                      (String) The date and time when the resource was created in RFC3339 format.
-                      The date and time when the resource was created in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
+                    description: (String) The date and time when the resource was
+                      created in RFC3339 format.
                     type: string
                   credentials:
-                    description: The applied parameters of the managed service instance
+                    description: (String) The applied credentials of the managed service
+                      instance.
                     format: byte
                     type: string
                   dashboardUrl:
-                    description: |-
-                      (String) The URL to the service instance dashboard (or null if there is none); only shown when type is managed.
-                      The URL to the service instance dashboard (or null if there is none); only shown when type is managed.
+                    description: (String) The URL to the service instance dashboard
+                      (or null if there is none); only shown when `type` is `managed`.
                     type: string
                   id:
-                    description: The GUID of the service instance
+                    description: (String) The GUID of the service instance.
                     type: string
                   labels:
                     additionalProperties:
                       type: string
-                    description: |-
-                      (Map of String) The labels associated with Cloud Foundry resources. Add as described here.
-                      The labels associated with Cloud Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
+                    description: (Map of String) The labels associated with Cloud
+                      Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
                     type: object
                     x-kubernetes-map-type: granular
                   lastAsyncJob:
-                    description: The job GUID of the last async operation performed
-                      on the resource
+                    description: (String) The job GUID of the last async operation
+                      performed on the resource.
                     type: string
                   lastOperation:
                     description: (Attributes) The details of the last operation performed
-                      on the resource (see below for nested schema)
+                      on the resource.
                     properties:
                       createdAt:
                         description: (String) The date and time when the resource
@@ -544,55 +531,54 @@ spec:
                     type: object
                   maintenanceInfo:
                     description: (Attributes) Information about the version of this
-                      service instance; only shown when type is managed (see below
-                      for nested schema)
+                      service instance; only shown when `type` is `managed`.
                     properties:
                       description:
-                        description: (String) A description of the last operation
+                        description: (String) A description of the last operation.
                         type: string
                       version:
-                        description: (String) The version of the service instance
+                        description: (String) The version of the service instance.
                         type: string
                     type: object
                   name:
-                    description: The name of the service instance
+                    description: (String) The name of the service instance.
                     type: string
                   parameters:
-                    description: The applied parameters of the managed service instance
-                      (TO BE IMPLEMENTED)
+                    description: (Attributes) The applied parameters of the managed
+                      service instance (TO BE IMPLEMENTED).
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   routeServiceUrl:
-                    description: URL to which requests for bound routes will be forwarded;
-                      only shown when type is user-provided.
+                    description: (String) URL to which requests for bound routes will
+                      be forwarded; only shown when `type` is `user-provided`.
                     type: string
                   servicePlan:
-                    description: The GUID of the Service Plan for a managed service
+                    description: (String) The GUID of the service plan for a managed
+                      service instance.
                     type: string
                   space:
-                    description: The GUID of the space in which the service instance
-                      was created
+                    description: (String) The GUID of the space in which the service
+                      instance was created.
                     type: string
                   syslogDrainUrl:
-                    description: URL to which logs for bound applications will be
-                      streamed; only shown when type is user-provided.
+                    description: (String) URL to which logs for bound applications
+                      will be streamed; only shown when `type` is `user-provided`.
                     type: string
                   tags:
-                    description: |-
-                      (List of String) List of tags used by apps to identify service instances. They are shown in the app VCAP_SERVICES env.
-                      List of tags used by apps to identify service instances. They are shown in the app VCAP_SERVICES env.
+                    description: (List of String) List of tags used by apps to identify
+                      service instances. They are shown in the app VCAP_SERVICES env.
                     items:
                       type: string
                     type: array
                   updatedAt:
-                    description: |-
-                      (String) The date and time when the resource was updated in RFC3339 format.
-                      The date and time when the resource was updated in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
+                    description: (String) The date and time when the resource was
+                      updated in RFC3339 format.
                     type: string
                   upgradeAvailable:
-                    description: |-
-                      (Boolean) Whether or not an upgrade of this service instance is available on the current Service Plan; details are available in the maintenance_info object; Only shown when type is managed
-                      Whether or not an upgrade of this service instance is available on the current Service Plan; details are available in the maintenance_info object; Only shown when type is managed
+                    description: (Boolean) Whether or not an upgrade of this service
+                      instance is available on the current service plan; details are
+                      available in the `maintenanceInfo` object; only shown when `type`
+                      is `managed`.
                     type: boolean
                 type: object
               conditions:

--- a/package/crds/cloudfoundry.crossplane.io_spacemembers.yaml
+++ b/package/crds/cloudfoundry.crossplane.io_spacemembers.yaml
@@ -55,7 +55,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: SpaceMembersSpec defines the desired state of SpaceMembers
+            description: SpaceMembersSpec defines the desired state of SpaceMembers.
             properties:
               deletionPolicy:
                 default: Delete
@@ -73,43 +73,45 @@ spec:
                 type: string
               forProvider:
                 description: SpaceMembersParameters encapsulate role assignments to
-                  CloudFoundry Spaces
+                  CloudFoundry Spaces.
                 properties:
                   enforcementPolicy:
                     default: Lax
-                    description: Set to `Lax` to enforce that the role is assigned
-                      to AT LEAST those members as defined in this CR. Set to `Strict`
-                      to enforce that the role is assigned to EXACT those members
-                      as defined in CR and any other members will be removed. Defaults
-                      to `Lax`.
+                    description: (String) Set to `Lax` to enforce that the role is
+                      assigned to AT LEAST those members as defined in this CR. Set
+                      to `Strict` to enforce that the role is assigned to EXACTLY
+                      those members as defined in this CR and any other members will
+                      be removed. Defaults to `Lax`.
                     enum:
                     - Lax
                     - Strict
                     type: string
                   members:
-                    description: List of members (usernames) to assign as org members
-                      with the specified role type. Defaults to empty list.
+                    description: (List of Attributes) List of members (usernames)
+                      to assign as org members with the specified role type. Defaults
+                      to empty list.
                     items:
-                      description: Member identifies a user by name and origin
+                      description: Member identifies a user by name and origin.
                       properties:
                         origin:
                           default: sap.ids
-                          description: Origin picks the IDP
+                          description: (String) Origin selects the identity provider.
+                            Defaults to "sap.ids".
                           type: string
                         username:
-                          description: Username at the identity provider
+                          description: (String) Username at the identity provider.
                           type: string
                       required:
                       - username
                       type: object
                     type: array
                   orgName:
-                    description: The name of the Cloud Foundry organization containing
-                      the space.
+                    description: (String) The name of the Cloud Foundry organization
+                      containing the space.
                     type: string
                   roleType:
-                    description: Space role type to assign to members; see valid role
-                      types https://v3-apidocs.cloudfoundry.space/version/3.127.0/index.html#valid-role-types
+                    description: (String) Space role type to assign to members; see
+                      valid role types https://v3-apidocs.cloudfoundry.space/version/3.127.0/index.html#valid-role-types
                     enum:
                     - Developer
                     - Auditor
@@ -121,19 +123,19 @@ spec:
                     - Supporters
                     type: string
                   space:
-                    description: The `guid` of the Cloud Foundry space. This field
-                      is typically populated using references specified in `spaceRef`,
+                    description: (String) The GUID of the Cloud Foundry space. This
+                      field is typically populated using references specified in `spaceRef`,
                       `spaceSelector`, or `spaceName`.
                     type: string
                   spaceName:
-                    description: The name of the Cloud Foundry space to lookup the
-                      `guid` of the Space. Use `spaceName` only when the reference
-                      Space is not managed by Crossplane.
+                    description: (String) The name of the Cloud Foundry space to lookup
+                      the GUID of the space. Use `spaceName` only when the referenced
+                      space is not managed by Crossplane.
                     type: string
                   spaceRef:
-                    description: Reference to a `Space` CR to lookup the `guid` of
-                      the Cloud Foundry space. Preferred if the reference space is
-                      managed by Crossplane.
+                    description: (Attributes) Reference to a `Space` CR to lookup
+                      the GUID of the Cloud Foundry space. Preferred if the referenced
+                      space is managed by Crossplane.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -167,9 +169,9 @@ spec:
                     - name
                     type: object
                   spaceSelector:
-                    description: Selector for a `Space` CR to lookup the `guid` of
-                      the Cloud Foundry space. Preferred if the reference space is
-                      managed by Crossplane.
+                    description: (Attributes) Selector for a `Space` CR to lookup
+                      the GUID of the Cloud Foundry space. Preferred if the referenced
+                      space is managed by Crossplane.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -383,13 +385,13 @@ spec:
             description: SpaceMembersStatus defines the observed state of SpaceMembers.
             properties:
               atProvider:
-                description: RoleAssignments maps members to roles
+                description: (Attributes) The assigned roles for the space members.
                 properties:
                   assignedRoles:
                     additionalProperties:
                       type: string
-                    description: '`AssignedRoles` maps member to GUIDs of the assigned
-                      Role objects.'
+                    description: (Map of String) `assignedRoles` maps a member to
+                      the GUID of the assigned Role object.
                     type: object
                 type: object
               conditions:

--- a/package/crds/cloudfoundry.crossplane.io_spacequotas.yaml
+++ b/package/crds/cloudfoundry.crossplane.io_spacequotas.yaml
@@ -74,27 +74,25 @@ spec:
               forProvider:
                 properties:
                   allowPaidServicePlans:
-                    description: |-
-                      free service plans. Does not control plan visibility. When false, non-free service plans may be visible in the marketplace but instances can not be provisioned.
-                      Determines whether users can provision instances of non-free service plans. Does not control plan visibility. When false, non-free service plans may be visible in the marketplace but instances can not be provisioned.
+                    description: (Boolean) Determines whether users can provision
+                      instances of non-free service plans. Does not control plan visibility.
+                      When false, non-free service plans may be visible in the marketplace
+                      but instances cannot be provisioned.
                     type: boolean
                   instanceMemory:
-                    description: |-
-                      (Number) Maximum memory per application instance.
-                      Maximum memory per application instance.
+                    description: (Number) Maximum memory per application instance.
                     type: number
                   name:
-                    description: |-
-                      (String) The name you use to identify the quota or plan in Cloud Foundry
-                      The name you use to identify the quota or plan in Cloud Foundry
+                    description: (String) The name you use to identify the quota or
+                      plan in Cloud Foundry.
                     type: string
                   org:
-                    description: |-
-                      (String) The ID of the Org within which to create the space quota
-                      The ID of the Org within which to create the space quota
+                    description: (String) The ID of the Org within which to create
+                      the space quota.
                     type: string
                   orgRef:
-                    description: Reference to a Org in resources to populate org.
+                    description: (Attributes) Reference to an Org in resources to
+                      populate `org`.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -128,7 +126,8 @@ spec:
                     - name
                     type: object
                   orgSelector:
-                    description: Selector for a Org in resources to populate org.
+                    description: (Attributes) Selector for an Org in resources to
+                      populate `org`.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -168,15 +167,15 @@ spec:
                         type: object
                     type: object
                   spaces:
-                    description: |-
-                      (Set of String) Set of space GUIDs to which this space quota would be assigned.
-                      Set of space GUIDs to which this space quota would be assigned.
+                    description: (Set of String) Set of space GUIDs to which this
+                      space quota would be assigned.
                     items:
                       type: string
                     type: array
                     x-kubernetes-list-type: set
                   spacesRefs:
-                    description: References to Space in cloudfoundry to populate spaces.
+                    description: (Attributes) References to Space in cloudfoundry
+                      to populate `spaces`.
                     items:
                       description: A Reference to a named object.
                       properties:
@@ -213,8 +212,8 @@ spec:
                       type: object
                     type: array
                   spacesSelector:
-                    description: Selector for a list of Space in cloudfoundry to populate
-                      spaces.
+                    description: (Attributes) Selector for a list of Space in cloudfoundry
+                      to populate `spaces`.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -254,44 +253,30 @@ spec:
                         type: object
                     type: object
                   totalAppInstances:
-                    description: |-
-                      (Number) Maximum app instances allowed.
-                      Maximum app instances allowed.
+                    description: (Number) Maximum app instances allowed.
                     type: number
                   totalAppLogRateLimit:
-                    description: |-
-                      (Number) Maximum log rate allowed for all the started processes and running tasks in bytes/second.
-                      Maximum log rate allowed for all the started processes and running tasks in bytes/second.
+                    description: (Number) Maximum log rate allowed for all the started
+                      processes and running tasks in bytes/second.
                     type: number
                   totalAppTasks:
-                    description: |-
-                      (Number) Maximum tasks allowed per app.
-                      Maximum tasks allowed per app.
+                    description: (Number) Maximum tasks allowed per app.
                     type: number
                   totalMemory:
-                    description: |-
-                      (Number) Maximum memory usage allowed.
-                      Maximum memory usage allowed.
+                    description: (Number) Maximum memory usage allowed.
                     type: number
                   totalRoutePorts:
-                    description: |-
-                      (Number) Total number of ports that are reservable by routes in a space.
-                      Total number of ports that are reservable by routes in a space.
+                    description: (Number) Total number of ports that are reservable
+                      by routes in a space.
                     type: number
                   totalRoutes:
-                    description: |-
-                      (Number) Maximum routes allowed.
-                      Maximum routes allowed.
+                    description: (Number) Maximum routes allowed.
                     type: number
                   totalServiceKeys:
-                    description: |-
-                      (Number) Maximum service keys allowed.
-                      Maximum service keys allowed.
+                    description: (Number) Maximum service keys allowed.
                     type: number
                   totalServices:
-                    description: |-
-                      (Number) Maximum services allowed.
-                      Maximum services allowed.
+                    description: (Number) Maximum services allowed.
                     type: number
                 type: object
               initProvider:
@@ -308,27 +293,25 @@ spec:
                   autoscaler.
                 properties:
                   allowPaidServicePlans:
-                    description: |-
-                      free service plans. Does not control plan visibility. When false, non-free service plans may be visible in the marketplace but instances can not be provisioned.
-                      Determines whether users can provision instances of non-free service plans. Does not control plan visibility. When false, non-free service plans may be visible in the marketplace but instances can not be provisioned.
+                    description: (Boolean) Determines whether users can provision
+                      instances of non-free service plans. Does not control plan visibility.
+                      When false, non-free service plans may be visible in the marketplace
+                      but instances cannot be provisioned.
                     type: boolean
                   instanceMemory:
-                    description: |-
-                      (Number) Maximum memory per application instance.
-                      Maximum memory per application instance.
+                    description: (Number) Maximum memory per application instance.
                     type: number
                   name:
-                    description: |-
-                      (String) The name you use to identify the quota or plan in Cloud Foundry
-                      The name you use to identify the quota or plan in Cloud Foundry
+                    description: (String) The name you use to identify the quota or
+                      plan in Cloud Foundry.
                     type: string
                   org:
-                    description: |-
-                      (String) The ID of the Org within which to create the space quota
-                      The ID of the Org within which to create the space quota
+                    description: (String) The ID of the Org within which to create
+                      the space quota.
                     type: string
                   orgRef:
-                    description: Reference to a Org in resources to populate org.
+                    description: (Attributes) Reference to an Org in resources to
+                      populate `org`.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -362,7 +345,8 @@ spec:
                     - name
                     type: object
                   orgSelector:
-                    description: Selector for a Org in resources to populate org.
+                    description: (Attributes) Selector for an Org in resources to
+                      populate `org`.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -402,15 +386,15 @@ spec:
                         type: object
                     type: object
                   spaces:
-                    description: |-
-                      (Set of String) Set of space GUIDs to which this space quota would be assigned.
-                      Set of space GUIDs to which this space quota would be assigned.
+                    description: (Set of String) Set of space GUIDs to which this
+                      space quota would be assigned.
                     items:
                       type: string
                     type: array
                     x-kubernetes-list-type: set
                   spacesRefs:
-                    description: References to Space in cloudfoundry to populate spaces.
+                    description: (Attributes) References to Space in cloudfoundry
+                      to populate `spaces`.
                     items:
                       description: A Reference to a named object.
                       properties:
@@ -447,8 +431,8 @@ spec:
                       type: object
                     type: array
                   spacesSelector:
-                    description: Selector for a list of Space in cloudfoundry to populate
-                      spaces.
+                    description: (Attributes) Selector for a list of Space in cloudfoundry
+                      to populate `spaces`.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -488,44 +472,30 @@ spec:
                         type: object
                     type: object
                   totalAppInstances:
-                    description: |-
-                      (Number) Maximum app instances allowed.
-                      Maximum app instances allowed.
+                    description: (Number) Maximum app instances allowed.
                     type: number
                   totalAppLogRateLimit:
-                    description: |-
-                      (Number) Maximum log rate allowed for all the started processes and running tasks in bytes/second.
-                      Maximum log rate allowed for all the started processes and running tasks in bytes/second.
+                    description: (Number) Maximum log rate allowed for all the started
+                      processes and running tasks in bytes/second.
                     type: number
                   totalAppTasks:
-                    description: |-
-                      (Number) Maximum tasks allowed per app.
-                      Maximum tasks allowed per app.
+                    description: (Number) Maximum tasks allowed per app.
                     type: number
                   totalMemory:
-                    description: |-
-                      (Number) Maximum memory usage allowed.
-                      Maximum memory usage allowed.
+                    description: (Number) Maximum memory usage allowed.
                     type: number
                   totalRoutePorts:
-                    description: |-
-                      (Number) Total number of ports that are reservable by routes in a space.
-                      Total number of ports that are reservable by routes in a space.
+                    description: (Number) Total number of ports that are reservable
+                      by routes in a space.
                     type: number
                   totalRoutes:
-                    description: |-
-                      (Number) Maximum routes allowed.
-                      Maximum routes allowed.
+                    description: (Number) Maximum routes allowed.
                     type: number
                   totalServiceKeys:
-                    description: |-
-                      (Number) Maximum service keys allowed.
-                      Maximum service keys allowed.
+                    description: (Number) Maximum service keys allowed.
                     type: number
                   totalServices:
-                    description: |-
-                      (Number) Maximum services allowed.
-                      Maximum services allowed.
+                    description: (Number) Maximum services allowed.
                     type: number
                 type: object
               managementPolicies:
@@ -710,85 +680,65 @@ spec:
               atProvider:
                 properties:
                   allowPaidServicePlans:
-                    description: |-
-                      free service plans. Does not control plan visibility. When false, non-free service plans may be visible in the marketplace but instances can not be provisioned.
-                      Determines whether users can provision instances of non-free service plans. Does not control plan visibility. When false, non-free service plans may be visible in the marketplace but instances can not be provisioned.
+                    description: (Boolean) Determines whether users can provision
+                      instances of non-free service plans. Does not control plan visibility.
+                      When false, non-free service plans may be visible in the marketplace
+                      but instances cannot be provisioned.
                     type: boolean
                   createdAt:
-                    description: |-
-                      (String) The date and time when the resource was created in RFC3339 format.
-                      The date and time when the resource was created in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
+                    description: (String) The date and time when the resource was
+                      created in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
                     type: string
                   id:
                     description: (String) The GUID of the object.
                     type: string
                   instanceMemory:
-                    description: |-
-                      (Number) Maximum memory per application instance.
-                      Maximum memory per application instance.
+                    description: (Number) Maximum memory per application instance.
                     type: number
                   name:
-                    description: |-
-                      (String) The name you use to identify the quota or plan in Cloud Foundry
-                      The name you use to identify the quota or plan in Cloud Foundry
+                    description: (String) The name you use to identify the quota or
+                      plan in Cloud Foundry.
                     type: string
                   org:
-                    description: |-
-                      (String) The ID of the Org within which to create the space quota
-                      The ID of the Org within which to create the space quota
+                    description: (String) The ID of the Org within which to create
+                      the space quota.
                     type: string
                   spaces:
-                    description: |-
-                      (Set of String) Set of space GUIDs to which this space quota would be assigned.
-                      Set of space GUIDs to which this space quota would be assigned.
+                    description: (Set of String) Set of space GUIDs to which this
+                      space quota would be assigned.
                     items:
                       type: string
                     type: array
                     x-kubernetes-list-type: set
                   totalAppInstances:
-                    description: |-
-                      (Number) Maximum app instances allowed.
-                      Maximum app instances allowed.
+                    description: (Number) Maximum app instances allowed.
                     type: number
                   totalAppLogRateLimit:
-                    description: |-
-                      (Number) Maximum log rate allowed for all the started processes and running tasks in bytes/second.
-                      Maximum log rate allowed for all the started processes and running tasks in bytes/second.
+                    description: (Number) Maximum log rate allowed for all the started
+                      processes and running tasks in bytes/second.
                     type: number
                   totalAppTasks:
-                    description: |-
-                      (Number) Maximum tasks allowed per app.
-                      Maximum tasks allowed per app.
+                    description: (Number) Maximum tasks allowed per app.
                     type: number
                   totalMemory:
-                    description: |-
-                      (Number) Maximum memory usage allowed.
-                      Maximum memory usage allowed.
+                    description: (Number) Maximum memory usage allowed.
                     type: number
                   totalRoutePorts:
-                    description: |-
-                      (Number) Total number of ports that are reservable by routes in a space.
-                      Total number of ports that are reservable by routes in a space.
+                    description: (Number) Total number of ports that are reservable
+                      by routes in a space.
                     type: number
                   totalRoutes:
-                    description: |-
-                      (Number) Maximum routes allowed.
-                      Maximum routes allowed.
+                    description: (Number) Maximum routes allowed.
                     type: number
                   totalServiceKeys:
-                    description: |-
-                      (Number) Maximum service keys allowed.
-                      Maximum service keys allowed.
+                    description: (Number) Maximum service keys allowed.
                     type: number
                   totalServices:
-                    description: |-
-                      (Number) Maximum services allowed.
-                      Maximum services allowed.
+                    description: (Number) Maximum services allowed.
                     type: number
                   updatedAt:
-                    description: |-
-                      (String) The date and time when the resource was updated in RFC3339 format.
-                      The date and time when the resource was updated in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
+                    description: (String) The date and time when the resource was
+                      updated in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
                     type: string
                 type: object
               conditions:

--- a/package/crds/cloudfoundry.crossplane.io_spaceroles.yaml
+++ b/package/crds/cloudfoundry.crossplane.io_spaceroles.yaml
@@ -75,28 +75,26 @@ spec:
               forProvider:
                 properties:
                   orgName:
-                    description: The name of the Cloud Foundry organization containing
-                      the space.
+                    description: (String) The name of the Cloud Foundry organization
+                      containing the space.
                     type: string
                   origin:
-                    description: |-
-                      (String) The identity provider for the UAA user
-                      The identity provider for the UAA user
+                    description: (String) The identity provider for the UAA user.
                     type: string
                   space:
-                    description: The `guid` of the Cloud Foundry space. This field
-                      is typically populated using references specified in `spaceRef`,
+                    description: (String) The GUID of the Cloud Foundry space. This
+                      field is typically populated using references specified in `spaceRef`,
                       `spaceSelector`, or `spaceName`.
                     type: string
                   spaceName:
-                    description: The name of the Cloud Foundry space to lookup the
-                      `guid` of the Space. Use `spaceName` only when the reference
-                      Space is not managed by Crossplane.
+                    description: (String) The name of the Cloud Foundry space to lookup
+                      the GUID of the space. Use `spaceName` only when the referenced
+                      space is not managed by Crossplane.
                     type: string
                   spaceRef:
-                    description: Reference to a `Space` CR to lookup the `guid` of
-                      the Cloud Foundry space. Preferred if the reference space is
-                      managed by Crossplane.
+                    description: (Attributes) Reference to a `Space` CR to lookup
+                      the GUID of the Cloud Foundry space. Preferred if the referenced
+                      space is managed by Crossplane.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -130,9 +128,9 @@ spec:
                     - name
                     type: object
                   spaceSelector:
-                    description: Selector for a `Space` CR to lookup the `guid` of
-                      the Cloud Foundry space. Preferred if the reference space is
-                      managed by Crossplane.
+                    description: (Attributes) Selector for a `Space` CR to lookup
+                      the GUID of the Cloud Foundry space. Preferred if the referenced
+                      space is managed by Crossplane.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -172,9 +170,7 @@ spec:
                         type: object
                     type: object
                   type:
-                    description: |-
-                      (String) SpaceRole type; see Valid role types
-                      SpaceRole type; see [Valid role types](https://v3-apidocs.cloudfoundry.org/version/3.154.0/index.html#valid-role-types)
+                    description: (String) The space role type; see [Valid role types](https://v3-apidocs.cloudfoundry.org/version/3.154.0/index.html#valid-role-types).
                     enum:
                     - Developer
                     - Auditor
@@ -186,9 +182,8 @@ spec:
                     - Supporters
                     type: string
                   username:
-                    description: |-
-                      (String) The username of the cloudfoundry user to assign the role with
-                      The username of the cloudfoundry user to assign the role with
+                    description: (String) The username of the Cloud Foundry user to
+                      assign the role to.
                     type: string
                 type: object
               managementPolicies:
@@ -364,35 +359,29 @@ spec:
               atProvider:
                 properties:
                   createdAt:
-                    description: |-
-                      (String) The date and time when the resource was created in RFC3339 format.
-                      The date and time when the resource was created in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
+                    description: (String) The date and time when the resource was
+                      created in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
                     type: string
                   id:
                     description: (String) The GUID of the object.
                     type: string
                   origin:
-                    description: |-
-                      (String) The identity provider for the UAA user
-                      The identity provider for the UAA user
+                    description: (String) The identity provider for the UAA user.
                     type: string
                   type:
-                    description: (String) SpaceRole type; see Valid role types
+                    description: (String) The space role type; see [Valid role types](https://v3-apidocs.cloudfoundry.org/version/3.154.0/index.html#valid-role-types).
                     type: string
                   updatedAt:
-                    description: |-
-                      (String) The date and time when the resource was updated in RFC3339 format.
-                      The date and time when the resource was updated in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
+                    description: (String) The date and time when the resource was
+                      updated in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
                     type: string
                   user:
-                    description: |-
-                      (String) The guid of the cloudfoundry user to assign the role with
-                      The guid of the cloudfoundry user to assign the role with
+                    description: (String) The GUID of the Cloud Foundry user to assign
+                      the role to.
                     type: string
                   username:
-                    description: |-
-                      (String) The username of the cloudfoundry user to assign the role with
-                      The username of the cloudfoundry user to assign the role with
+                    description: (String) The username of the Cloud Foundry user to
+                      assign the role to.
                     type: string
                 type: object
               conditions:

--- a/package/crds/cloudfoundry.crossplane.io_spaces.yaml
+++ b/package/crds/cloudfoundry.crossplane.io_spaces.yaml
@@ -55,7 +55,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: SpaceSpec defines the desired state of Space
+            description: SpaceSpec defines the desired state of Space.
             properties:
               deletionPolicy:
                 default: Delete
@@ -75,46 +75,41 @@ spec:
                 properties:
                   allowSsh:
                     default: false
-                    description: |-
-                      (Boolean) Allows SSH to application containers via the CF CLI.
-                      Allows SSH to application containers via the CF CLI.
+                    description: (Boolean) Allows SSH to application containers via
+                      the CF CLI.
                     type: boolean
                   annotations:
                     additionalProperties:
                       type: string
-                    description: |-
-                      (Map of String) The annotations associated with Cloud Foundry resources. Add as described here.
-                      The annotations associated with Cloud Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
+                    description: (Map of String) The annotations associated with Cloud
+                      Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
                     type: object
                     x-kubernetes-map-type: granular
                   isolationSegment:
-                    description: |-
-                      (String) The ID of the isolation segment to assign to the space. The isolation segment must be entitled to the space's parent organization
-                      The ID of the isolation segment to assign to the space. The isolation segment must be entitled to the space's parent organization
+                    description: (String) The ID of the isolation segment to assign
+                      to the space. The isolation segment must be entitled to the
+                      space's parent organization.
                     type: string
                   labels:
                     additionalProperties:
                       type: string
-                    description: |-
-                      (Map of String) The labels associated with Cloud Foundry resources. Add as described here.
-                      The labels associated with Cloud Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
+                    description: (Map of String) The labels associated with Cloud
+                      Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
                     type: object
                     x-kubernetes-map-type: granular
                   name:
-                    description: |-
-                      (String) The name of the Space in Cloud Foundry
-                      The name of the Space in Cloud Foundry
+                    description: (String) The name of the space in Cloud Foundry.
                     type: string
                   org:
-                    description: (String) The guid of the organization
+                    description: (String) The GUID of the organization.
                     type: string
                   orgName:
-                    description: The name of the Cloud Foundry organization containing
-                      the space.
+                    description: (String) The name of the Cloud Foundry organization
+                      containing the space.
                     type: string
                   orgRef:
-                    description: Reference to an `Org` CR to retrieve the external
-                      GUID of the organization.
+                    description: (Attributes) Reference to an `Org` CR to retrieve
+                      the external GUID of the organization.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -148,8 +143,8 @@ spec:
                     - name
                     type: object
                   orgSelector:
-                    description: Selector to an `Org` CR to retrieve the external
-                      GUID of the Organization.
+                    description: (Attributes) Selector to an `Org` CR to retrieve
+                      the external GUID of the organization.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -362,58 +357,49 @@ spec:
               atProvider:
                 properties:
                   allowSsh:
-                    description: |-
-                      (Boolean) Allows SSH to application containers via the CF CLI.
-                      Allows SSH to application containers via the CF CLI.
+                    description: (Boolean) Allows SSH to application containers via
+                      the CF CLI.
                     type: boolean
                   annotations:
                     additionalProperties:
                       type: string
-                    description: |-
-                      (Map of String) The annotations associated with Cloud Foundry resources. Add as described here.
-                      The annotations associated with Cloud Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
+                    description: (Map of String) The annotations associated with Cloud
+                      Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
                     type: object
                     x-kubernetes-map-type: granular
                   createdAt:
-                    description: |-
-                      (String) The date and time when the resource was created in RFC3339 format.
-                      The date and time when the resource was created in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
+                    description: (String) The date and time when the resource was
+                      created in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
                     type: string
                   id:
                     description: (String) The GUID of the object.
                     type: string
                   isolationSegment:
-                    description: |-
-                      (String) The ID of the isolation segment to assign to the space. The isolation segment must be entitled to the space's parent organization
-                      The ID of the isolation segment to assign to the space. The isolation segment must be entitled to the space's parent organization
+                    description: (String) The ID of the isolation segment to assign
+                      to the space. The isolation segment must be entitled to the
+                      space's parent organization.
                     type: string
                   labels:
                     additionalProperties:
                       type: string
-                    description: |-
-                      (Map of String) The labels associated with Cloud Foundry resources. Add as described here.
-                      The labels associated with Cloud Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
+                    description: (Map of String) The labels associated with Cloud
+                      Foundry resources. Add as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
                     type: object
                     x-kubernetes-map-type: granular
                   name:
-                    description: |-
-                      (String) The name of the Space in Cloud Foundry
-                      The name of the Space in Cloud Foundry
+                    description: (String) The name of the space in Cloud Foundry.
                     type: string
                   org:
-                    description: |-
-                      (String) The ID of the Org within which to create the space
-                      The ID of the Org within which to create the space
+                    description: (String) The ID of the organization within which
+                      to create the space.
                     type: string
                   quota:
-                    description: |-
-                      (String) The space quota applied to the space. To assign a space quota, use the space quota resource instead.
-                      The space quota applied to the space. To assign a space quota, use the space quota resource instead.
+                    description: (String) The space quota applied to the space. To
+                      assign a space quota, use the space quota resource instead.
                     type: string
                   updatedAt:
-                    description: |-
-                      (String) The date and time when the resource was updated in RFC3339 format.
-                      The date and time when the resource was updated in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
+                    description: (String) The date and time when the resource was
+                      updated in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
                     type: string
                 type: object
               conditions:


### PR DESCRIPTION
This PR adds a more unified look and feel to the field descriptors of all resources. These have been mostly generated but checked afterwards by me. 

Key Aspects include:
- If the attribute has a standard data type I want to have it in the first comment e.g. (String), otherwise for nested structs I want to use the (Attributes) tag
- Cleanup faulty and legacy descriptions
- Every time when referencing a parameter this should be done via its actual json tag e.g. `orgRef` instead of OrgRef. 

Backlog:
- https://github.com/orgs/SAP/projects/128/views/1?pane=issue&itemId=117243054&issue=SAP%7Ccrossplane-provider-cloudfoundry%7C82