### PR TITLE
feat: add enhanced validation rules

### DIFF
--- a/apis/resources/v1alpha1/app_types.go
+++ b/apis/resources/v1alpha1/app_types.go
@@ -265,6 +265,8 @@ type AppStatus struct {
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,cloudfoundry}
+// +kubebuilder:validation:XValidation:rule="self.spec.managementPolicies == ['Observe'] || (has(self.spec.forProvider.spaceName) || has(self.spec.forProvider.spaceRef) || has(self.spec.forProvider.spaceSelector))",message="SpaceReference is required: exactly one of spaceName, spaceRef, or spaceSelector must be set"
+// +kubebuilder:validation:XValidation:rule="[has(self.spec.forProvider.spaceName), has(self.spec.forProvider.spaceRef), has(self.spec.forProvider.spaceSelector)].filter(x, x).size() <= 1",message="SpaceReference validation: only one of spaceName, spaceRef, or spaceSelector can be set"
 type App struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/resources/v1alpha1/route_types.go
+++ b/apis/resources/v1alpha1/route_types.go
@@ -114,6 +114,10 @@ type RouteStatus struct {
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,cloudfoundry}
+// +kubebuilder:validation:XValidation:rule="self.spec.managementPolicies == ['Observe'] || (has(self.spec.forProvider.spaceName) || has(self.spec.forProvider.spaceRef) || has(self.spec.forProvider.spaceSelector))",message="SpaceReference is required: exactly one of spaceName, spaceRef, or spaceSelector must be set"
+// +kubebuilder:validation:XValidation:rule="[has(self.spec.forProvider.spaceName), has(self.spec.forProvider.spaceRef), has(self.spec.forProvider.spaceSelector)].filter(x, x).size() <= 1",message="SpaceReference validation: only one of spaceName, spaceRef, or spaceSelector can be set"
+// +kubebuilder:validation:XValidation:rule="self.spec.managementPolicies == ['Observe'] || (has(self.spec.forProvider.domainName) || has(self.spec.forProvider.domainRef) || has(self.spec.forProvider.domainSelector))",message="DomainReference is required: exactly one of domainName, domainRef, or domainSelector must be set"
+// +kubebuilder:validation:XValidation:rule="[has(self.spec.forProvider.domainName), has(self.spec.forProvider.domainRef), has(self.spec.forProvider.domainSelector)].filter(x, x).size() <= 1",message="DomainReference validation: only one of domainName, domainRef, or domainSelector can be set"
 type Route struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/resources/v1alpha1/serviceinstance_types.go
+++ b/apis/resources/v1alpha1/serviceinstance_types.go
@@ -230,12 +230,14 @@ type ServiceInstanceStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
 
-// ServiceInstance is the Schema for the ServiceInstances API. Creates a service instance in a Cloud Foundry space. Further documentation: https://docs.cloudfoundry.org/devguide/services
+// ServiceInstance is the Schema for the ServiceInstances API. Provides a Cloud Foundry resource for managing service instances.
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,cloudfoundry}
+// +kubebuilder:validation:XValidation:rule="self.spec.managementPolicies == ['Observe'] || (has(self.spec.forProvider.spaceName) || has(self.spec.forProvider.spaceRef) || has(self.spec.forProvider.spaceSelector))",message="SpaceReference is required: exactly one of spaceName, spaceRef, or spaceSelector must be set"
+// +kubebuilder:validation:XValidation:rule="[has(self.spec.forProvider.spaceName), has(self.spec.forProvider.spaceRef), has(self.spec.forProvider.spaceSelector)].filter(x, x).size() <= 1",message="SpaceReference validation: only one of spaceName, spaceRef, or spaceSelector can be set"
 type ServiceInstance struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/resources/v1alpha1/spacemember_types.go
+++ b/apis/resources/v1alpha1/spacemember_types.go
@@ -43,6 +43,8 @@ type SpaceMembersStatus struct {
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,cloudfoundry}
+// +kubebuilder:validation:XValidation:rule="self.spec.managementPolicies == ['Observe'] || (has(self.spec.forProvider.spaceName) || has(self.spec.forProvider.spaceRef) || has(self.spec.forProvider.spaceSelector))",message="SpaceReference is required: exactly one of spaceName, spaceRef, or spaceSelector must be set"
+// +kubebuilder:validation:XValidation:rule="[has(self.spec.forProvider.spaceName), has(self.spec.forProvider.spaceRef), has(self.spec.forProvider.spaceSelector)].filter(x, x).size() <= 1",message="SpaceReference validation: only one of spaceName, spaceRef, or spaceSelector can be set"
 type SpaceMembers struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/resources/v1alpha1/spacerole_types.go
+++ b/apis/resources/v1alpha1/spacerole_types.go
@@ -76,6 +76,8 @@ type SpaceRoleStatus struct {
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,cloudfoundry}
+// +kubebuilder:validation:XValidation:rule="self.spec.managementPolicies == ['Observe'] || (has(self.spec.forProvider.spaceName) || has(self.spec.forProvider.spaceRef) || has(self.spec.forProvider.spaceSelector))",message="SpaceReference is required: exactly one of spaceName, spaceRef, or spaceSelector must be set"
+// +kubebuilder:validation:XValidation:rule="[has(self.spec.forProvider.spaceName), has(self.spec.forProvider.spaceRef), has(self.spec.forProvider.spaceSelector)].filter(x, x).size() <= 1",message="SpaceReference validation: only one of spaceName, spaceRef, or spaceSelector can be set"
 type SpaceRole struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/package/crds/cloudfoundry.crossplane.io_apps.yaml
+++ b/package/crds/cloudfoundry.crossplane.io_apps.yaml
@@ -766,6 +766,15 @@ spec:
         required:
         - spec
         type: object
+        x-kubernetes-validations:
+        - message: 'SpaceReference is required: exactly one of spaceName, spaceRef,
+            or spaceSelector must be set'
+          rule: self.spec.managementPolicies == ['Observe'] || (has(self.spec.forProvider.spaceName)
+            || has(self.spec.forProvider.spaceRef) || has(self.spec.forProvider.spaceSelector))
+        - message: 'SpaceReference validation: only one of spaceName, spaceRef, or
+            spaceSelector can be set'
+          rule: '[has(self.spec.forProvider.spaceName), has(self.spec.forProvider.spaceRef),
+            has(self.spec.forProvider.spaceSelector)].filter(x, x).size() <= 1'
     served: true
     storage: true
     subresources:

--- a/package/crds/cloudfoundry.crossplane.io_routes.yaml
+++ b/package/crds/cloudfoundry.crossplane.io_routes.yaml
@@ -567,6 +567,23 @@ spec:
         required:
         - spec
         type: object
+        x-kubernetes-validations:
+        - message: 'SpaceReference is required: exactly one of spaceName, spaceRef,
+            or spaceSelector must be set'
+          rule: self.spec.managementPolicies == ['Observe'] || (has(self.spec.forProvider.spaceName)
+            || has(self.spec.forProvider.spaceRef) || has(self.spec.forProvider.spaceSelector))
+        - message: 'SpaceReference validation: only one of spaceName, spaceRef, or
+            spaceSelector can be set'
+          rule: '[has(self.spec.forProvider.spaceName), has(self.spec.forProvider.spaceRef),
+            has(self.spec.forProvider.spaceSelector)].filter(x, x).size() <= 1'
+        - message: 'DomainReference is required: exactly one of domainName, domainRef,
+            or domainSelector must be set'
+          rule: self.spec.managementPolicies == ['Observe'] || (has(self.spec.forProvider.domainName)
+            || has(self.spec.forProvider.domainRef) || has(self.spec.forProvider.domainSelector))
+        - message: 'DomainReference validation: only one of domainName, domainRef,
+            or domainSelector can be set'
+          rule: '[has(self.spec.forProvider.domainName), has(self.spec.forProvider.domainRef),
+            has(self.spec.forProvider.domainSelector)].filter(x, x).size() <= 1'
     served: true
     storage: true
     subresources:

--- a/package/crds/cloudfoundry.crossplane.io_serviceinstances.yaml
+++ b/package/crds/cloudfoundry.crossplane.io_serviceinstances.yaml
@@ -34,9 +34,8 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: 'ServiceInstance is the Schema for the ServiceInstances API.
-          Creates a service instance in a Cloud Foundry space. Further documentation:
-          https://docs.cloudfoundry.org/devguide/services'
+        description: ServiceInstance is the Schema for the ServiceInstances API. Provides
+          a Cloud Foundry resource for managing service instances.
         properties:
           apiVersion:
             description: |-
@@ -638,6 +637,15 @@ spec:
         required:
         - spec
         type: object
+        x-kubernetes-validations:
+        - message: 'SpaceReference is required: exactly one of spaceName, spaceRef,
+            or spaceSelector must be set'
+          rule: self.spec.managementPolicies == ['Observe'] || (has(self.spec.forProvider.spaceName)
+            || has(self.spec.forProvider.spaceRef) || has(self.spec.forProvider.spaceSelector))
+        - message: 'SpaceReference validation: only one of spaceName, spaceRef, or
+            spaceSelector can be set'
+          rule: '[has(self.spec.forProvider.spaceName), has(self.spec.forProvider.spaceRef),
+            has(self.spec.forProvider.spaceSelector)].filter(x, x).size() <= 1'
     served: true
     storage: true
     subresources:

--- a/package/crds/cloudfoundry.crossplane.io_spacemembers.yaml
+++ b/package/crds/cloudfoundry.crossplane.io_spacemembers.yaml
@@ -451,6 +451,15 @@ spec:
         required:
         - spec
         type: object
+        x-kubernetes-validations:
+        - message: 'SpaceReference is required: exactly one of spaceName, spaceRef,
+            or spaceSelector must be set'
+          rule: self.spec.managementPolicies == ['Observe'] || (has(self.spec.forProvider.spaceName)
+            || has(self.spec.forProvider.spaceRef) || has(self.spec.forProvider.spaceSelector))
+        - message: 'SpaceReference validation: only one of spaceName, spaceRef, or
+            spaceSelector can be set'
+          rule: '[has(self.spec.forProvider.spaceName), has(self.spec.forProvider.spaceRef),
+            has(self.spec.forProvider.spaceSelector)].filter(x, x).size() <= 1'
     served: true
     storage: true
     subresources:

--- a/package/crds/cloudfoundry.crossplane.io_spaceroles.yaml
+++ b/package/crds/cloudfoundry.crossplane.io_spaceroles.yaml
@@ -441,6 +441,15 @@ spec:
         required:
         - spec
         type: object
+        x-kubernetes-validations:
+        - message: 'SpaceReference is required: exactly one of spaceName, spaceRef,
+            or spaceSelector must be set'
+          rule: self.spec.managementPolicies == ['Observe'] || (has(self.spec.forProvider.spaceName)
+            || has(self.spec.forProvider.spaceRef) || has(self.spec.forProvider.spaceSelector))
+        - message: 'SpaceReference validation: only one of spaceName, spaceRef, or
+            spaceSelector can be set'
+          rule: '[has(self.spec.forProvider.spaceName), has(self.spec.forProvider.spaceRef),
+            has(self.spec.forProvider.spaceSelector)].filter(x, x).size() <= 1'
     served: true
     storage: true
     subresources:


### PR DESCRIPTION
This PR closes #80.

It implements additional validation rules for multiple resources to make the CRDs more robust.


**Rules added**
-  If `spec.managementPolicies` is Observe only, then `spec.forProvider` may be empty, regardless of whether the fields are required. 
- SpaceReference is required. Only one of `forProvider.spaceName`, `forProvider.spaceRef`, or `forProvider.spaceSelector` can be set.
- DomainReference is required. Only one of `domainName`, `domainRef`, or `domainSelector`  can be set.

**Resources modified**:
-  `App`
- `Route`
- `ServiceInstance`
- `SpaceMembers`
- `SpaceRole`