### PR TITLE
fix[114]: fixing ServiceInstance creation without credentials

### DIFF
--- a/examples/resources/orgspace.yaml
+++ b/examples/resources/orgspace.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: cloudfoundry.crossplane.io/v1alpha1
-kind: Org
+kind: Organization
 metadata:
   namespace: default
   name: my-org

--- a/examples/serviceinstance/ups-without-credentials.yaml
+++ b/examples/serviceinstance/ups-without-credentials.yaml
@@ -1,0 +1,16 @@
+---
+# UPS without service credentials 
+apiVersion: cloudfoundry.crossplane.io/v1alpha1
+kind: ServiceInstance
+metadata:
+  name: my-ups
+spec:
+  forProvider:
+    type: user-provided
+    name: my-ups
+    routeServiceUrl: https://my-route-service.example.com
+    syslogDrainUrl: syslog-tls://example.log-aggregator.com:6514
+    spaceRef: 
+      name: my-space
+      policy:
+        resolve: Always

--- a/internal/clients/serviceinstance/serviceinstance.go
+++ b/internal/clients/serviceinstance/serviceinstance.go
@@ -152,7 +152,7 @@ func (c *Client) Create(ctx context.Context, spec v1alpha1.ServiceInstanceParame
 		return c.createManaged(ctx, spec, creds)
 
 	case v1alpha1.UserProvidedService:
-		return c.createUserProvided(ctx, spec, creds)
+		return c.createUserProvided(ctx, spec)
 	default:
 		return nil, errors.New("unknown service instance type")
 	}
@@ -185,12 +185,7 @@ func (c *Client) createManaged(ctx context.Context, spec v1alpha1.ServiceInstanc
 }
 
 // createUserProvided creates a user-provided service instance according to CR's ForProvider spec
-func (c *Client) createUserProvided(ctx context.Context, spec v1alpha1.ServiceInstanceParameters, creds json.RawMessage) (*resource.ServiceInstance, error) {
-	// Credential is required for UPS
-	if creds == nil {
-		return nil, errors.New("Missing or invalid credentials")
-	}
-
+func (c *Client) createUserProvided(ctx context.Context, spec v1alpha1.ServiceInstanceParameters) (*resource.ServiceInstance, error) {
 	// throw error if no space is provided
 	if spec.Space == nil {
 		return nil, errors.New("no space reference provided")
@@ -204,7 +199,6 @@ func (c *Client) createUserProvided(ctx context.Context, spec v1alpha1.ServiceIn
 
 	// workaround: cf-goclient supports few ups options at creation time.
 	upt := resource.NewServiceInstanceUserProvidedUpdate().
-		WithCredentials(creds).
 		WithRouteServiceURL(spec.RouteServiceURL).
 		WithSyslogDrainURL(spec.SyslogDrainURL)
 

--- a/internal/clients/serviceinstance/serviceinstance.go
+++ b/internal/clients/serviceinstance/serviceinstance.go
@@ -152,7 +152,7 @@ func (c *Client) Create(ctx context.Context, spec v1alpha1.ServiceInstanceParame
 		return c.createManaged(ctx, spec, creds)
 
 	case v1alpha1.UserProvidedService:
-		return c.createUserProvided(ctx, spec)
+		return c.createUserProvided(ctx, spec, creds)
 	default:
 		return nil, errors.New("unknown service instance type")
 	}
@@ -185,7 +185,7 @@ func (c *Client) createManaged(ctx context.Context, spec v1alpha1.ServiceInstanc
 }
 
 // createUserProvided creates a user-provided service instance according to CR's ForProvider spec
-func (c *Client) createUserProvided(ctx context.Context, spec v1alpha1.ServiceInstanceParameters) (*resource.ServiceInstance, error) {
+func (c *Client) createUserProvided(ctx context.Context, spec v1alpha1.ServiceInstanceParameters, creds json.RawMessage) (*resource.ServiceInstance, error) {
 	// throw error if no space is provided
 	if spec.Space == nil {
 		return nil, errors.New("no space reference provided")
@@ -198,8 +198,11 @@ func (c *Client) createUserProvided(ctx context.Context, spec v1alpha1.ServiceIn
 	}
 
 	// workaround: cf-goclient supports few ups options at creation time.
-	upt := resource.NewServiceInstanceUserProvidedUpdate().
-		WithRouteServiceURL(spec.RouteServiceURL).
+	upt := resource.NewServiceInstanceUserProvidedUpdate()
+	if creds != nil {
+		upt.WithCredentials(creds)
+	}
+	upt.WithRouteServiceURL(spec.RouteServiceURL).
 		WithSyslogDrainURL(spec.SyslogDrainURL)
 
 	return c.ServiceInstance.UpdateUserProvided(ctx, si.GUID, upt)
@@ -259,15 +262,15 @@ func (c *Client) updateManaged(ctx context.Context, observed *resource.ServiceIn
 func (c *Client) updateUserProvided(ctx context.Context, observed *resource.ServiceInstance, desired *v1alpha1.ServiceInstanceParameters, creds json.RawMessage) (*resource.ServiceInstance, error) {
 	upd := resource.NewServiceInstanceUserProvidedUpdate()
 
-	if creds == nil {
-		return nil, errors.New("Missing or invalid credentials")
-
-	}
 	if observed.Name != *desired.Name {
 		upd.WithName(*desired.Name)
 	}
 
-	upd.WithRouteServiceURL(desired.RouteServiceURL).WithSyslogDrainURL(desired.SyslogDrainURL).WithCredentials(creds)
+	if creds != nil {
+		upd.WithCredentials(creds)
+	}
+	upd.WithRouteServiceURL(desired.RouteServiceURL).
+		WithSyslogDrainURL(desired.SyslogDrainURL)
 
 	return c.ServiceInstance.UpdateUserProvided(ctx, observed.GUID, upd)
 }

--- a/test/e2e/cloudfoundry_services_test.go
+++ b/test/e2e/cloudfoundry_services_test.go
@@ -28,10 +28,11 @@ func TestCloudFoundryServices(t *testing.T) {
 		// updated checks if resource is updated, normally by observing a new value on managed field.
 		updated func(k8s.Object) (bool, error)
 	}{
-		"space":            {name: "service-space", obj: &v1alpha1.Space{}},
-		"service_instance": {name: "e2e-service-instance", obj: &v1alpha1.ServiceInstance{}},
-		"ups":              {name: "e2e-ups", obj: &v1alpha1.ServiceInstance{}},
-		"scb_key":          {name: "e2e-scb-key", obj: &v1alpha1.ServiceCredentialBinding{}},
+		"space":              {name: "service-space", obj: &v1alpha1.Space{}},
+		"service_instance":   {name: "e2e-service-instance", obj: &v1alpha1.ServiceInstance{}},
+		"ups":                {name: "e2e-ups", obj: &v1alpha1.ServiceInstance{}},
+		"ups_no_credentials": {name: "e2e-ups-no-credentials", obj: &v1alpha1.ServiceInstance{}},
+		"scb_key":            {name: "e2e-scb-key", obj: &v1alpha1.ServiceCredentialBinding{}},
 	}
 
 	var feat = features.New("CO-159 cloudfoundry e2e test services").Setup(

--- a/test/e2e/crs/service/ups_no_credentials.yaml
+++ b/test/e2e/crs/service/ups_no_credentials.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   forProvider:
     type: user-provided
-    name: 2e-ups-no-credentials
+    name: e2e-ups-no-credentials
     routeServiceUrl: https://e2e-route-service.example.com
     syslogDrainUrl: syslog-tls://example.log-aggregator.com:6514
     spaceRef: 

--- a/test/e2e/crs/service/ups_no_credentials.yaml
+++ b/test/e2e/crs/service/ups_no_credentials.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: cloudfoundry.crossplane.io/v1alpha1
+kind: ServiceInstance
+metadata:
+  namespace: service-test
+  name: e2e-ups-no-credentials
+spec:
+  forProvider:
+    type: user-provided
+    name: 2e-ups-no-credentials
+    routeServiceUrl: https://e2e-route-service.example.com
+    syslogDrainUrl: syslog-tls://example.log-aggregator.com:6514
+    spaceRef: 
+      name: service-space
+      policy:
+        resolve: Always


### PR DESCRIPTION
This PR fixes #114 

ServiceInstance with type user-provided should be possible create without credentials.