### PR TITLE
chore: add renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "postUpdateOptions": [
+    "gomodTidy"
+  ]
+}


### PR DESCRIPTION
Use renovate for dependency updates. Copied from crossplane-provider-btp.
We could also use dependabot but renovate is a bit more flexible when it comes to more advanced version matching (we use in provider-btp, maybe we also need this here).