### PR TITLE
fix: Handle empty LastOperation state for user-provided services

### DIFF
--- a/internal/controller/serviceinstance/controller.go
+++ b/internal/controller/serviceinstance/controller.go
@@ -187,8 +187,9 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 			ResourceExists:   r.LastOperation.Type != v1alpha1.LastOperationCreate, // set to false when the last operation is create, hence the reconciler will retry create
 			ResourceUpToDate: r.LastOperation.Type != v1alpha1.LastOperationUpdate, // set to false when the last operation is update, hence the reconciler will retry update
 		}, nil
-	case v1alpha1.LastOperationSucceeded:
+	case v1alpha1.LastOperationSucceeded, "":
 		// If the last operation succeeded, set the CR to available
+		// Empty state is treated as succeeded (happens with user-provided services that have no async operations)
 		cr.SetConditions(xpv1.Available())
 		var credentialsUpToDate bool
 		desiredCredentials, err := extractCredentialSpec(ctx, c.kube, cr.Spec.ForProvider)

--- a/internal/controller/serviceinstance/controller_test.go
+++ b/internal/controller/serviceinstance/controller_test.go
@@ -491,6 +491,39 @@ func TestObserve(t *testing.T) {
 				)
 				return m
 			},
+		},
+		"UserProvidedService_EmptyLastOperation": {
+			args: args{
+				mg: serviceInstance("user-provided", withExternalName(guid), withSpace(spaceGUID), withCredentials(&jsonCredentials), withStatus(v1alpha1.ServiceInstanceObservation{Credentials: iSha256([]byte(jsonCredentials))})),
+			},
+			want: want{
+				mg: serviceInstance("user-provided",
+					withExternalName(guid),
+					withSpace(spaceGUID),
+					withCredentials(&jsonCredentials),
+					withStatus(v1alpha1.ServiceInstanceObservation{ID: &guid, Credentials: iSha256([]byte(jsonCredentials))}),
+					withConditions(xpv1.Available()),
+				),
+				obs: managed.ExternalObservation{ResourceExists: true, ResourceUpToDate: true},
+				err: nil,
+			},
+			service: func() *fake.MockServiceInstance {
+				m := &fake.MockServiceInstance{}
+				// User-provided services have empty LastOperation
+				m.On("Get", guid).Return(
+					&fake.NewServiceInstance("user-provided").SetName(name).SetGUID(guid).SetLastOperation("", "").ServiceInstance,
+					nil,
+				)
+				m.On("Single").Return(
+					&fake.NewServiceInstance("user-provided").SetName(name).SetGUID(guid).SetLastOperation("", "").ServiceInstance,
+					nil,
+				)
+				m.On("GetUserProvidedCredentials", guid).Return(
+					fake.JSONRawMessage(jsonCredentials),
+					nil,
+				)
+				return m
+			},
 		}}
 
 	for n, tc := range cases {


### PR DESCRIPTION
 ## Overview

  This PR fixes issue #201 where user-provided Cloud Foundry services fail reconciliation with the error "unknown last operation state" despite being successfully created in BTP.

  ## Problem

  Cloud Foundry has two types of service instances with different operation behaviors:

  | Type | Behavior |
  |------|----------|
  | **Managed services** | Provisioned asynchronously by service brokers; always have a `LastOperation.State` |
  | **User-provided services** | Created synchronously without a broker; may have an **empty** `LastOperation.State` |

  User-provided services are created synchronously without async operations, resulting in an empty `LastOperation` object (empty `Type` and `State` fields). Since these services don't go through an async
  provisioning workflow, they never receive operation state updates.

  Previously, the `Observe` method treated an empty `LastOperation.State` as an unknown state and threw an error, causing reconciliation to fail even though the service was successfully created and ready to use.

  ## Solution

  This fix treats an empty `LastOperation.State` the same as `succeeded` state, since an existing user-provided service with no async operation is ready and available.

  **Changes:**
  - Modified the switch case in `controller.go:190` to handle empty string alongside `LastOperationSucceeded`
  - Added test case `UserProvidedService_EmptyLastOperation` to verify the fix

  ## Testing

  - ✅ All existing tests pass
  - ✅ New test case added for empty `LastOperation` state
  - ✅ Linter passes

  Fixes #201