### PR TITLE
feat(exporter): add Cloud Foundry App resource export support

### DIFF
--- a/.github/workflows/test-docs-build.yaml
+++ b/.github/workflows/test-docs-build.yaml
@@ -17,7 +17,7 @@ jobs:
     with:
       provider-repo: ${{ github.event.pull_request.head.repo.full_name }}
       provider-ref: ${{ github.event.pull_request.head.sha }}
-      submodule-path: docs
+      submodule-path: docs/crossplane-provider-cloudfoundry
 
   test-docs-build-push:
     if: github.event_name == 'push'
@@ -25,4 +25,4 @@ jobs:
     with:
       provider-repo: ${{ github.repository }}
       provider-ref: ${{ github.sha }}
-      submodule-path: docs
+      submodule-path: docs/crossplane-provider-cloudfoundry

--- a/.github/workflows/test-docs-build.yaml
+++ b/.github/workflows/test-docs-build.yaml
@@ -17,7 +17,7 @@ jobs:
     with:
       provider-repo: ${{ github.event.pull_request.head.repo.full_name }}
       provider-ref: ${{ github.event.pull_request.head.sha }}
-      submodule-path: docs/crossplane-provider-cloudfoundry
+      submodule-path: docs
 
   test-docs-build-push:
     if: github.event_name == 'push'
@@ -25,4 +25,4 @@ jobs:
     with:
       provider-repo: ${{ github.repository }}
       provider-ref: ${{ github.sha }}
-      submodule-path: docs/crossplane-provider-cloudfoundry
+      submodule-path: docs

--- a/cmd/exporter/cf/app/app.go
+++ b/cmd/exporter/cf/app/app.go
@@ -1,3 +1,6 @@
+// Package app implements Cloud Foundry App resource export functionality.
+// It fetches CF applications from the API, converts them to Crossplane App resources,
+// and handles filtering by organization and space.
 package app
 
 import (
@@ -32,15 +35,19 @@ func init() {
 	resources.RegisterKind(app{})
 }
 
+// res wraps a Cloud Foundry App with comment metadata for YAML export.
 type res struct {
 	*resource.App
 	*yaml.ResourceWithComment
 }
 
+// GetGUID returns the Cloud Foundry GUID of the application.
 func (r *res) GetGUID() string {
 	return r.GUID
 }
 
+// GetName returns the sanitized name of the application suitable for Kubernetes resources.
+// If sanitization fails, a warning comment is added to the resource.
 func (r *res) GetName() string {
 	name := r.Name
 	names := parsan.ParseAndSanitize(name, parsan.RFC1035LowerSubdomain)
@@ -52,18 +59,23 @@ func (r *res) GetName() string {
 	return name
 }
 
+// app implements the resources.Kind interface for CF App export.
 type app struct{}
 
 var _ resources.Kind = app{}
 
+// Param returns the configuration parameter for filtering apps during export.
 func (a app) Param() configparam.ConfigParam {
 	return param
 }
 
+// KindName returns the name of this resource kind ("app").
 func (a app) KindName() string {
 	return param.GetName()
 }
 
+// Export fetches CF applications, converts them to Crossplane resources, and emits them via the event handler.
+// It filters apps by organization/space and processes each matching application.
 func (a app) Export(ctx context.Context, cfClient *client.Client, evHandler export.EventHandler, resolveReferences bool) error {
 	apps, err := Get(ctx, cfClient)
 	if err != nil {
@@ -83,6 +95,7 @@ func (a app) Export(ctx context.Context, cfClient *client.Client, evHandler expo
 	return nil
 }
 
+// getAllNamesFn returns a function that fetches all app names for the given org/space GUIDs.
 func getAllNamesFn(ctx context.Context, cfClient *client.Client, orgGuids, spaceGuids []string) func() ([]string, error) {
 	return func() ([]string, error) {
 		resources, err := getAll(ctx, cfClient, orgGuids, spaceGuids, []string{})
@@ -97,6 +110,8 @@ func getAllNamesFn(ctx context.Context, cfClient *client.Client, orgGuids, space
 	}
 }
 
+// Get returns all CF applications matching the configured filter criteria.
+// Results are cached for subsequent calls. It prompts for app selection if none are specified.
 func Get(ctx context.Context, cfClient *client.Client) (mkcontainer.TypedContainer[*res], error) {
 	if c != nil {
 		return c, nil
@@ -143,6 +158,8 @@ func Get(ctx context.Context, cfClient *client.Client) (mkcontainer.TypedContain
 	return c, nil
 }
 
+// getAll retrieves applications from the CF API and filters them by the provided name patterns.
+// Supports regex matching for app names. If appNames is empty, matches all applications.
 func getAll(ctx context.Context, cfClient *client.Client, orgGuids, spaceGuids, appNames []string) ([]*res, error) {
 	var nameRxs []*regexp.Regexp
 

--- a/cmd/exporter/cf/app/app.go
+++ b/cmd/exporter/cf/app/app.go
@@ -1,0 +1,187 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"regexp"
+	"time"
+
+	"github.com/SAP/crossplane-provider-cloudfoundry/cmd/exporter/cf/guidname"
+	"github.com/SAP/crossplane-provider-cloudfoundry/cmd/exporter/cf/org"
+	"github.com/SAP/crossplane-provider-cloudfoundry/cmd/exporter/cf/resources"
+	"github.com/SAP/crossplane-provider-cloudfoundry/cmd/exporter/cf/space"
+
+	"github.com/SAP/xp-clifford/cli/configparam"
+	"github.com/SAP/xp-clifford/cli/export"
+	"github.com/SAP/xp-clifford/erratt"
+	"github.com/SAP/xp-clifford/mkcontainer"
+	"github.com/SAP/xp-clifford/parsan"
+	"github.com/SAP/xp-clifford/yaml"
+	"github.com/cloudfoundry/go-cfclient/v3/client"
+	"github.com/cloudfoundry/go-cfclient/v3/resource"
+)
+
+var (
+	c     mkcontainer.TypedContainer[*res]
+	param = configparam.StringSlice("app", "Filter for Cloud Foundry apps").
+		WithFlagName("app")
+)
+
+func init() {
+	resources.RegisterKind(app{})
+}
+
+type res struct {
+	*resource.App
+	*yaml.ResourceWithComment
+}
+
+func (r *res) GetGUID() string {
+	return r.GUID
+}
+
+func (r *res) GetName() string {
+	name := r.Name
+	names := parsan.ParseAndSanitize(name, parsan.RFC1035LowerSubdomain)
+	if len(names) == 0 {
+		r.AddComment(fmt.Sprintf("error sanitizing name: %s", name))
+	} else {
+		name = names[0]
+	}
+	return name
+}
+
+type app struct{}
+
+var _ resources.Kind = app{}
+
+func (a app) Param() configparam.ConfigParam {
+	return param
+}
+
+func (a app) KindName() string {
+	return param.GetName()
+}
+
+func (a app) Export(ctx context.Context, cfClient *client.Client, evHandler export.EventHandler, resolveReferences bool) error {
+	apps, err := Get(ctx, cfClient)
+	if err != nil {
+		return err
+	}
+	if apps.IsEmpty() {
+		evHandler.Warn(erratt.New("no apps found", "apps", param.Value()))
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+	defer cancel()
+	for _, app := range apps.AllByGUIDs() {
+		slog.Debug("exporting app", "name", app.Name)
+		evHandler.Resource(convertAppResource(ctx, cfClient, app, evHandler, resolveReferences))
+	}
+
+	return nil
+}
+
+func getAllNamesFn(ctx context.Context, cfClient *client.Client, orgGuids, spaceGuids []string) func() ([]string, error) {
+	return func() ([]string, error) {
+		resources, err := getAll(ctx, cfClient, orgGuids, spaceGuids, []string{})
+		if err != nil {
+			return nil, err
+		}
+		names := make([]string, len(resources))
+		for i, res := range resources {
+			names[i] = guidname.NewName(res).String()
+		}
+		return names, nil
+	}
+}
+
+func Get(ctx context.Context, cfClient *client.Client) (mkcontainer.TypedContainer[*res], error) {
+	if c != nil {
+		return c, nil
+	}
+	orgs, err := org.Get(ctx, cfClient)
+	if err != nil {
+		return nil, err
+	}
+	spaces, err := space.Get(ctx, cfClient)
+	if err != nil {
+		return nil, err
+	}
+
+	param.WithPossibleValuesFn(getAllNamesFn(ctx, cfClient, orgs.GetGUIDs(), spaces.GetGUIDs()))
+
+	selectedApps, err := param.ValueOrAsk(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	appNames := make([]string, len(selectedApps))
+	for i, appName := range selectedApps {
+		name, err := guidname.ParseName(appName)
+		if err != nil {
+			return nil, err
+		}
+		appNames[i] = name.Name
+	}
+	slog.Debug("apps selected", "apps", selectedApps, "appNames", appNames)
+	ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	defer cancel()
+	apps, err := getAll(ctx,
+		cfClient,
+		orgs.GetGUIDs(),
+		spaces.GetGUIDs(),
+		appNames,
+	)
+	if err != nil {
+		return nil, err
+	}
+	c = mkcontainer.NewTyped[*res]()
+	c.Store(apps...)
+	slog.Debug("apps collected", "apps", c.GetNames())
+	return c, nil
+}
+
+func getAll(ctx context.Context, cfClient *client.Client, orgGuids, spaceGuids, appNames []string) ([]*res, error) {
+	var nameRxs []*regexp.Regexp
+
+	if len(appNames) > 0 {
+		for _, appName := range appNames {
+			slog.Debug("processing app", "name", appName)
+			rx, err := regexp.Compile(appName)
+			if err != nil {
+				return nil, erratt.Errorf("cannot compile name to regexp: %w", err).With("appName", appName)
+			}
+			nameRxs = append(nameRxs, rx)
+		}
+	} else {
+		nameRxs = []*regexp.Regexp{
+			regexp.MustCompile(`.*`),
+		}
+	}
+
+	listOptions := client.NewAppListOptions()
+	if len(orgGuids) > 0 {
+		listOptions.OrganizationGUIDs.Values = orgGuids
+		listOptions.SpaceGUIDs.Values = spaceGuids
+	}
+	apps, err := cfClient.Applications.ListAll(ctx, listOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	var results []*res
+	for _, app := range apps {
+		for _, nameRx := range nameRxs {
+			if nameRx.MatchString(app.Name) {
+				slog.Debug("matching app found", "rx", nameRx.String(), "found", app.Name)
+				results = append(results, &res{
+					ResourceWithComment: yaml.NewResourceWithComment(nil),
+					App:                 app,
+				})
+			}
+		}
+	}
+	return results, nil
+}

--- a/cmd/exporter/cf/app/convert.go
+++ b/cmd/exporter/cf/app/convert.go
@@ -1,0 +1,155 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/SAP/crossplane-provider-cloudfoundry/apis/resources/v1alpha1"
+	"github.com/SAP/crossplane-provider-cloudfoundry/cmd/exporter/cf/space"
+
+	"github.com/SAP/xp-clifford/cli/export"
+	"github.com/SAP/xp-clifford/erratt"
+	"github.com/SAP/xp-clifford/parsan"
+	"github.com/SAP/xp-clifford/yaml"
+	"github.com/cloudfoundry/go-cfclient/v3/client"
+	"github.com/cloudfoundry/go-cfclient/v3/operation"
+	v1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func convertDockerField(app *res, managedApp *v1alpha1.App, appManifest *operation.AppManifest, evHandler export.EventHandler) error {
+	docker := appManifest.Docker
+
+	if docker == nil {
+		return erratt.New("invalid application manifest: missing docker",
+			"app-name", app.GetName(),
+			"app-manifest", appManifest)
+	}
+
+	managedApp.Spec.ForProvider.Docker = &v1alpha1.DockerConfiguration{
+		Image: docker.Image,
+	}
+	if username := docker.Username; username != "" {
+		secretNames := parsan.ParseAndSanitize(
+			fmt.Sprintf("%s.docker-credentials", app.GetName()),
+			parsan.RFC1035SubdomainRelaxed)
+		if len(secretNames) == 0 {
+			erra := erratt.New(
+				"cannot sanitize docker credentials secret name",
+				"app-name", app.GetName(),
+			)
+			evHandler.Warn(erra)
+		} else {
+			secretName := secretNames[0]
+			evHandler.Resource(generateDockerCredentialSecret(secretName, username))
+			managedApp.Spec.ForProvider.Docker.Credentials = &v1.SecretReference{
+				Name: secretName,
+			}
+		}
+	}
+	return nil
+}
+
+func convertProcessesField(managedApp *v1alpha1.App, appManifest *operation.AppManifest) {
+	if appManifest.Processes == nil {
+		return
+	}
+	if len(*appManifest.Processes) == 0 {
+		return
+	}
+
+	managedApp.Spec.ForProvider.Processes = make([]v1alpha1.ProcessConfiguration, len(*appManifest.Processes))
+	for i, process := range *appManifest.Processes {
+		managedApp.Spec.ForProvider.Processes[i] = v1alpha1.ProcessConfiguration{
+			Type:      (*string)(&process.Type),
+			Command:   &process.Command,
+			DiskQuota: &process.DiskQuota,
+			Instances: process.Instances,
+			Memory:    &process.Memory,
+			Timeout:   &process.Timeout,
+			HealthCheckConfiguration: v1alpha1.HealthCheckConfiguration{
+				HealthCheckType:              (*string)(&process.HealthCheckType),
+				HealthCheckHTTPEndpoint:      &process.HealthCheckHTTPEndpoint,
+				HealthCheckInterval:          &process.HealthCheckInterval,
+				HealthCheckInvocationTimeout: &process.HealthCheckInvocationTimeout,
+			},
+		}
+	}
+}
+
+func convertAppResource(ctx context.Context, cfClient *client.Client, app *res, evHandler export.EventHandler, resolveReferences bool) *yaml.ResourceWithComment {
+	slog.Debug("converting app", "name", app.Name)
+
+	managedApp := &v1alpha1.App{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       v1alpha1.App_Kind,
+			APIVersion: v1alpha1.CRDGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: app.GetName(),
+			Annotations: map[string]string{
+				"crossplane.io/external-name": app.GetGUID(),
+			},
+		},
+		Spec: v1alpha1.AppSpec{
+			ResourceSpec: v1.ResourceSpec{
+				ManagementPolicies: []v1.ManagementAction{
+					v1.ManagementActionObserve,
+				},
+			},
+			ForProvider: v1alpha1.AppParameters{
+				Name:      app.GetName(),
+				Lifecycle: app.Lifecycle.Type,
+				SpaceReference: v1alpha1.SpaceReference{
+					Space: &app.Relationships.Space.Data.GUID,
+				},
+				// Buildpacks:                        []string{}, // not supported yet
+				// Stack:                             new(string), // not supported yet
+				// Path:                              new(string), // not supported yet
+				// Routes:                            []v1alpha1.RouteConfiguration{}, // not supported yet
+				// Services:                          []v1alpha1.ServiceBindingConfiguration{}, // not supported yet
+
+				// Environment:                       &runtime.RawExtension{}, // not supported yetk
+			},
+		},
+	}
+
+	appWithComment := yaml.NewResourceWithComment(managedApp)
+	appWithComment.CloneComment(app.ResourceWithComment)
+
+	appManifest, err := getAppManifest(ctx, cfClient, app.GetGUID())
+	if err != nil {
+		erra := erratt.Errorf("cannot get app manifest: %w", err).With("app-name", app.GetName())
+		evHandler.Warn(erra)
+		appWithComment.AddComment(erra.Error())
+	} else {
+		slog.Debug("app manifest fetched", "app-manifest", appManifest, "app-name", app.GetName())
+
+		if app.Lifecycle.Type == "docker" {
+			err = convertDockerField(app, managedApp, appManifest, evHandler)
+			if err != nil {
+				evHandler.Warn(err)
+				appWithComment.AddComment(err.Error())
+			}
+		}
+		managedApp.Spec.ForProvider.NoRoute = appManifest.NoRoute
+		managedApp.Spec.ForProvider.RandomRoute = appManifest.RandomRoute
+		managedApp.Spec.ForProvider.DefaultRoute = appManifest.DefaultRoute
+		convertProcessesField(managedApp, appManifest)
+		managedApp.Spec.ForProvider.ReadinessHealthCheckConfiguration = v1alpha1.ReadinessHealthCheckConfiguration{
+			ReadinessHealthCheckType:              &appManifest.ReadinessHealthCheckType,
+			ReadinessHealthCheckHTTPEndpoint:      &appManifest.ReadinessHealthCheckHttpEndpoint,
+			ReadinessHealthCheckInterval:          &appManifest.ReadinessHealthCheckInterval,
+			ReadinessHealthCheckInvocationTimeout: &appManifest.ReadinessHealthInvocationTimeout,
+		}
+		managedApp.Spec.ForProvider.LogRateLimitPerSecond = &appManifest.LogRateLimitPerSecond
+	}
+	if resolveReferences {
+		if err := space.ResolveReference(ctx, cfClient, &managedApp.Spec.ForProvider.SpaceReference); err != nil {
+			erra := erratt.Errorf("cannot resolve space reference: %w", err).With("app-name", app.GetName())
+			evHandler.Warn(erra)
+		}
+	}
+	return appWithComment
+}

--- a/cmd/exporter/cf/app/convert.go
+++ b/cmd/exporter/cf/app/convert.go
@@ -1,3 +1,4 @@
+// Package app implements Cloud Foundry App resource export functionality.
 package app
 
 import (
@@ -18,6 +19,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// convertDockerField converts Docker configuration from CF manifest to Crossplane DockerConfiguration.
+// Generates a Secret for Docker credentials if username is provided. Password is set to "TODO" placeholder.
 func convertDockerField(app *res, managedApp *v1alpha1.App, appManifest *operation.AppManifest, evHandler export.EventHandler) error {
 	docker := appManifest.Docker
 
@@ -51,6 +54,8 @@ func convertDockerField(app *res, managedApp *v1alpha1.App, appManifest *operati
 	return nil
 }
 
+// convertProcessesField converts CF application processes to Crossplane ProcessConfiguration.
+// Handles all process types including web and worker processes with health checks.
 func convertProcessesField(managedApp *v1alpha1.App, appManifest *operation.AppManifest) {
 	if appManifest.Processes == nil {
 		return
@@ -78,6 +83,9 @@ func convertProcessesField(managedApp *v1alpha1.App, appManifest *operation.AppM
 	}
 }
 
+// convertAppResource converts a CF application to a Crossplane App resource with manifest data.
+// Fetches the app manifest, converts Docker config and processes, and optionally resolves space references.
+// Returns a ResourceWithComment containing the converted App and any warning comments.
 func convertAppResource(ctx context.Context, cfClient *client.Client, app *res, evHandler export.EventHandler, resolveReferences bool) *yaml.ResourceWithComment {
 	slog.Debug("converting app", "name", app.Name)
 

--- a/cmd/exporter/cf/app/convert.go
+++ b/cmd/exporter/cf/app/convert.go
@@ -150,7 +150,7 @@ func convertAppResource(ctx context.Context, cfClient *client.Client, app *res, 
 				},
 			},
 			ForProvider: v1alpha1.AppParameters{
-				Name:      app.GetName(),
+				Name:      app.Name,
 				Lifecycle: app.Lifecycle.Type,
 				SpaceReference: v1alpha1.SpaceReference{
 					Space: &app.Relationships.Space.Data.GUID,

--- a/cmd/exporter/cf/app/convert.go
+++ b/cmd/exporter/cf/app/convert.go
@@ -54,6 +54,40 @@ func convertDockerField(app *res, managedApp *v1alpha1.App, appManifest *operati
 	return nil
 }
 
+// convertProcessConfiguration converts a single CF AppManifestProcess to Crossplane ProcessConfiguration.
+// Handles all process fields including type, command, resources, and health check settings.
+func convertProcessConfiguration(process *operation.AppManifestProcess) *v1alpha1.ProcessConfiguration {
+	processConfig := &v1alpha1.ProcessConfiguration{
+		Type:      (*string)(&process.Type),
+		Instances: process.Instances,
+		HealthCheckConfiguration: v1alpha1.HealthCheckConfiguration{
+			HealthCheckType: (*string)(&process.HealthCheckType),
+		},
+	}
+	if process.Command != "" {
+		processConfig.Command = &process.Command
+	}
+	if process.DiskQuota != "" {
+		processConfig.DiskQuota = &process.DiskQuota
+	}
+	if process.Memory != "" {
+		processConfig.Memory = &process.Memory
+	}
+	if process.Timeout != 0 {
+		processConfig.Timeout = &process.Timeout
+	}
+	if process.HealthCheckHTTPEndpoint != "" {
+		processConfig.HealthCheckHTTPEndpoint = &process.HealthCheckHTTPEndpoint
+	}
+	if process.HealthCheckInterval != 0 {
+		processConfig.HealthCheckInterval = &process.HealthCheckInterval
+	}
+	if process.HealthCheckInvocationTimeout != 0 {
+		processConfig.HealthCheckInvocationTimeout = &process.HealthCheckInvocationTimeout
+	}
+	return processConfig
+}
+
 // convertProcessesField converts CF application processes to Crossplane ProcessConfiguration.
 // Handles all process types including web and worker processes with health checks.
 func convertProcessesField(managedApp *v1alpha1.App, appManifest *operation.AppManifest) {
@@ -66,21 +100,30 @@ func convertProcessesField(managedApp *v1alpha1.App, appManifest *operation.AppM
 
 	managedApp.Spec.ForProvider.Processes = make([]v1alpha1.ProcessConfiguration, len(*appManifest.Processes))
 	for i, process := range *appManifest.Processes {
-		managedApp.Spec.ForProvider.Processes[i] = v1alpha1.ProcessConfiguration{
-			Type:      (*string)(&process.Type),
-			Command:   &process.Command,
-			DiskQuota: &process.DiskQuota,
-			Instances: process.Instances,
-			Memory:    &process.Memory,
-			Timeout:   &process.Timeout,
-			HealthCheckConfiguration: v1alpha1.HealthCheckConfiguration{
-				HealthCheckType:              (*string)(&process.HealthCheckType),
-				HealthCheckHTTPEndpoint:      &process.HealthCheckHTTPEndpoint,
-				HealthCheckInterval:          &process.HealthCheckInterval,
-				HealthCheckInvocationTimeout: &process.HealthCheckInvocationTimeout,
-			},
-		}
+		managedApp.Spec.ForProvider.Processes[i] = *convertProcessConfiguration(&process)
 	}
+}
+
+// convertReadinessHealthCheckConfiguration converts readiness health check settings from CF manifest.
+// Returns a ReadinessHealthCheckConfiguration with only the fields that are set in the manifest.
+func convertReadinessHealthCheckConfiguration(appManifest *operation.AppManifest) *v1alpha1.ReadinessHealthCheckConfiguration {
+	rhcConfig := &v1alpha1.ReadinessHealthCheckConfiguration{}
+	if appManifest == nil {
+		return rhcConfig
+	}
+	if appManifest.ReadinessHealthCheckType != "" {
+		rhcConfig.ReadinessHealthCheckType = &appManifest.ReadinessHealthCheckType
+	}
+	if appManifest.ReadinessHealthCheckHttpEndpoint != "" {
+		rhcConfig.ReadinessHealthCheckHTTPEndpoint = &appManifest.ReadinessHealthCheckHttpEndpoint
+	}
+	if appManifest.ReadinessHealthCheckInterval != 0 {
+		rhcConfig.ReadinessHealthCheckInterval = &appManifest.ReadinessHealthCheckInterval
+	}
+	if appManifest.ReadinessHealthInvocationTimeout != 0 {
+		rhcConfig.ReadinessHealthCheckInvocationTimeout = &appManifest.ReadinessHealthInvocationTimeout
+	}
+	return rhcConfig
 }
 
 // convertAppResource converts a CF application to a Crossplane App resource with manifest data.
@@ -131,7 +174,7 @@ func convertAppResource(ctx context.Context, cfClient *client.Client, app *res, 
 		erra := erratt.Errorf("cannot get app manifest: %w", err).With("app-name", app.GetName())
 		evHandler.Warn(erra)
 		appWithComment.AddComment(erra.Error())
-	} else {
+	} else if appManifest != nil {
 		slog.Debug("app manifest fetched", "app-manifest", appManifest, "app-name", app.GetName())
 
 		if app.Lifecycle.Type == "docker" {
@@ -145,12 +188,7 @@ func convertAppResource(ctx context.Context, cfClient *client.Client, app *res, 
 		managedApp.Spec.ForProvider.RandomRoute = appManifest.RandomRoute
 		managedApp.Spec.ForProvider.DefaultRoute = appManifest.DefaultRoute
 		convertProcessesField(managedApp, appManifest)
-		managedApp.Spec.ForProvider.ReadinessHealthCheckConfiguration = v1alpha1.ReadinessHealthCheckConfiguration{
-			ReadinessHealthCheckType:              &appManifest.ReadinessHealthCheckType,
-			ReadinessHealthCheckHTTPEndpoint:      &appManifest.ReadinessHealthCheckHttpEndpoint,
-			ReadinessHealthCheckInterval:          &appManifest.ReadinessHealthCheckInterval,
-			ReadinessHealthCheckInvocationTimeout: &appManifest.ReadinessHealthInvocationTimeout,
-		}
+		managedApp.Spec.ForProvider.ReadinessHealthCheckConfiguration = *convertReadinessHealthCheckConfiguration(appManifest)
 		managedApp.Spec.ForProvider.LogRateLimitPerSecond = &appManifest.LogRateLimitPerSecond
 	}
 	if resolveReferences {

--- a/cmd/exporter/cf/app/convert_test.go
+++ b/cmd/exporter/cf/app/convert_test.go
@@ -338,7 +338,282 @@ func TestGenerateDockerCredentialSecret(t *testing.T) {
 	}
 }
 
+func TestConvertProcessConfiguration(t *testing.T) {
+	tests := []struct {
+		name    string
+		process operation.AppManifestProcess
+		check   func(t *testing.T, cfg *v1alpha1.ProcessConfiguration)
+	}{
+		{
+			name: "process with all fields set",
+			process: operation.AppManifestProcess{
+				Type:                         "web",
+				Command:                      "node server.js",
+				DiskQuota:                    "1G",
+				Instances:                    ptr.To[uint](3),
+				Memory:                       "512M",
+				Timeout:                      60,
+				HealthCheckType:              "http",
+				HealthCheckHTTPEndpoint:      "/health",
+				HealthCheckInterval:          30,
+				HealthCheckInvocationTimeout: 5,
+			},
+			check: func(t *testing.T, cfg *v1alpha1.ProcessConfiguration) {
+				if *cfg.Type != "web" {
+					t.Errorf("expected type 'web', got %s", *cfg.Type)
+				}
+				if *cfg.Command != "node server.js" {
+					t.Errorf("expected command 'node server.js', got %s", *cfg.Command)
+				}
+				if *cfg.DiskQuota != "1G" {
+					t.Errorf("expected disk quota '1G', got %s", *cfg.DiskQuota)
+				}
+				if *cfg.Instances != 3 {
+					t.Errorf("expected 3 instances, got %d", *cfg.Instances)
+				}
+				if *cfg.Memory != "512M" {
+					t.Errorf("expected memory '512M', got %s", *cfg.Memory)
+				}
+				if *cfg.Timeout != 60 {
+					t.Errorf("expected timeout 60, got %d", *cfg.Timeout)
+				}
+				if *cfg.HealthCheckType != "http" {
+					t.Errorf("expected health check type 'http', got %s", *cfg.HealthCheckType)
+				}
+				if *cfg.HealthCheckHTTPEndpoint != "/health" {
+					t.Errorf("expected health check endpoint '/health', got %s", *cfg.HealthCheckHTTPEndpoint)
+				}
+				if *cfg.HealthCheckInterval != 30 {
+					t.Errorf("expected health check interval 30, got %d", *cfg.HealthCheckInterval)
+				}
+				if *cfg.HealthCheckInvocationTimeout != 5 {
+					t.Errorf("expected health check invocation timeout 5, got %d", *cfg.HealthCheckInvocationTimeout)
+				}
+			},
+		},
+		{
+			name: "process with only required fields",
+			process: operation.AppManifestProcess{
+				Type:            "worker",
+				Instances:       ptr.To[uint](1),
+				HealthCheckType: "port",
+			},
+			check: func(t *testing.T, cfg *v1alpha1.ProcessConfiguration) {
+				if *cfg.Type != "worker" {
+					t.Errorf("expected type 'worker', got %s", *cfg.Type)
+				}
+				if cfg.Command != nil {
+					t.Errorf("expected nil command for empty value, got %v", *cfg.Command)
+				}
+				if cfg.DiskQuota != nil {
+					t.Errorf("expected nil disk quota for empty value, got %v", *cfg.DiskQuota)
+				}
+				if *cfg.Instances != 1 {
+					t.Errorf("expected 1 instance, got %d", *cfg.Instances)
+				}
+				if cfg.Memory != nil {
+					t.Errorf("expected nil memory for empty value, got %v", *cfg.Memory)
+				}
+				if cfg.Timeout != nil {
+					t.Errorf("expected nil timeout for zero value, got %v", *cfg.Timeout)
+				}
+				if *cfg.HealthCheckType != "port" {
+					t.Errorf("expected health check type 'port', got %s", *cfg.HealthCheckType)
+				}
+				if cfg.HealthCheckHTTPEndpoint != nil {
+					t.Errorf("expected nil health check endpoint for empty value, got %v", *cfg.HealthCheckHTTPEndpoint)
+				}
+				if cfg.HealthCheckInterval != nil {
+					t.Errorf("expected nil health check interval for zero value, got %v", *cfg.HealthCheckInterval)
+				}
+				if cfg.HealthCheckInvocationTimeout != nil {
+					t.Errorf("expected nil health check invocation timeout for zero value, got %v", *cfg.HealthCheckInvocationTimeout)
+				}
+			},
+		},
+		{
+			name: "process with partial fields",
+			process: operation.AppManifestProcess{
+				Type:                "web",
+				Command:             "python app.py",
+				Instances:           ptr.To[uint](2),
+				Memory:              "256M",
+				Timeout:             30,
+				HealthCheckType:     "http",
+				HealthCheckInterval: 10,
+			},
+			check: func(t *testing.T, cfg *v1alpha1.ProcessConfiguration) {
+				if *cfg.Type != "web" {
+					t.Errorf("expected type 'web', got %s", *cfg.Type)
+				}
+				if *cfg.Command != "python app.py" {
+					t.Errorf("expected command 'python app.py', got %s", *cfg.Command)
+				}
+				if cfg.DiskQuota != nil {
+					t.Errorf("expected nil disk quota for empty value, got %v", *cfg.DiskQuota)
+				}
+				if *cfg.Instances != 2 {
+					t.Errorf("expected 2 instances, got %d", *cfg.Instances)
+				}
+				if *cfg.Memory != "256M" {
+					t.Errorf("expected memory '256M', got %s", *cfg.Memory)
+				}
+				if *cfg.Timeout != 30 {
+					t.Errorf("expected timeout 30, got %d", *cfg.Timeout)
+				}
+				if cfg.HealthCheckHTTPEndpoint != nil {
+					t.Errorf("expected nil health check endpoint for empty value, got %v", *cfg.HealthCheckHTTPEndpoint)
+				}
+				if *cfg.HealthCheckInterval != 10 {
+					t.Errorf("expected health check interval 10, got %d", *cfg.HealthCheckInterval)
+				}
+				if cfg.HealthCheckInvocationTimeout != nil {
+					t.Errorf("expected nil health check invocation timeout for zero value, got %v", *cfg.HealthCheckInvocationTimeout)
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := convertProcessConfiguration(&tt.process)
+			if tt.check != nil {
+				tt.check(t, result)
+			}
+		})
+	}
+}
+
+func TestConvertReadinessHealthCheckConfiguration(t *testing.T) {
+	tests := []struct {
+		name        string
+		appManifest *operation.AppManifest
+		check       func(t *testing.T, cfg *v1alpha1.ReadinessHealthCheckConfiguration)
+	}{
+		{
+			name:        "nil manifest returns empty config",
+			appManifest: nil,
+			check: func(t *testing.T, cfg *v1alpha1.ReadinessHealthCheckConfiguration) {
+				if cfg.ReadinessHealthCheckType != nil {
+					t.Errorf("expected nil type for nil manifest, got %v", *cfg.ReadinessHealthCheckType)
+				}
+				if cfg.ReadinessHealthCheckHTTPEndpoint != nil {
+					t.Errorf("expected nil endpoint for nil manifest, got %v", *cfg.ReadinessHealthCheckHTTPEndpoint)
+				}
+				if cfg.ReadinessHealthCheckInterval != nil {
+					t.Errorf("expected nil interval for nil manifest, got %v", *cfg.ReadinessHealthCheckInterval)
+				}
+				if cfg.ReadinessHealthCheckInvocationTimeout != nil {
+					t.Errorf("expected nil timeout for nil manifest, got %v", *cfg.ReadinessHealthCheckInvocationTimeout)
+				}
+			},
+		},
+		{
+			name: "empty manifest returns empty config",
+			appManifest: &operation.AppManifest{
+				AppManifestProcess: operation.AppManifestProcess{
+					ReadinessHealthCheckType:         "",
+					ReadinessHealthCheckHttpEndpoint: "",
+					ReadinessHealthCheckInterval:     0,
+					ReadinessHealthInvocationTimeout: 0,
+				},
+			},
+			check: func(t *testing.T, cfg *v1alpha1.ReadinessHealthCheckConfiguration) {
+				if cfg.ReadinessHealthCheckType != nil {
+					t.Errorf("expected nil type for empty value, got %v", *cfg.ReadinessHealthCheckType)
+				}
+				if cfg.ReadinessHealthCheckHTTPEndpoint != nil {
+					t.Errorf("expected nil endpoint for empty value, got %v", *cfg.ReadinessHealthCheckHTTPEndpoint)
+				}
+				if cfg.ReadinessHealthCheckInterval != nil {
+					t.Errorf("expected nil interval for zero value, got %v", *cfg.ReadinessHealthCheckInterval)
+				}
+				if cfg.ReadinessHealthCheckInvocationTimeout != nil {
+					t.Errorf("expected nil timeout for zero value, got %v", *cfg.ReadinessHealthCheckInvocationTimeout)
+				}
+			},
+		},
+		{
+			name: "all fields set",
+			appManifest: &operation.AppManifest{
+				AppManifestProcess: operation.AppManifestProcess{
+					ReadinessHealthCheckType:         "http",
+					ReadinessHealthCheckHttpEndpoint: "/ready",
+					ReadinessHealthCheckInterval:     30,
+					ReadinessHealthInvocationTimeout: 5,
+				},
+			},
+			check: func(t *testing.T, cfg *v1alpha1.ReadinessHealthCheckConfiguration) {
+				if cfg.ReadinessHealthCheckType == nil || *cfg.ReadinessHealthCheckType != "http" {
+					t.Errorf("expected type 'http', got %v", cfg.ReadinessHealthCheckType)
+				}
+				if cfg.ReadinessHealthCheckHTTPEndpoint == nil || *cfg.ReadinessHealthCheckHTTPEndpoint != "/ready" {
+					t.Errorf("expected endpoint '/ready', got %v", cfg.ReadinessHealthCheckHTTPEndpoint)
+				}
+				if cfg.ReadinessHealthCheckInterval == nil || *cfg.ReadinessHealthCheckInterval != 30 {
+					t.Errorf("expected interval 30, got %v", cfg.ReadinessHealthCheckInterval)
+				}
+				if cfg.ReadinessHealthCheckInvocationTimeout == nil || *cfg.ReadinessHealthCheckInvocationTimeout != 5 {
+					t.Errorf("expected timeout 5, got %v", cfg.ReadinessHealthCheckInvocationTimeout)
+				}
+			},
+		},
+		{
+			name: "partial fields set - only type",
+			appManifest: &operation.AppManifest{
+				AppManifestProcess: operation.AppManifestProcess{
+					ReadinessHealthCheckType: "port",
+				},
+			},
+			check: func(t *testing.T, cfg *v1alpha1.ReadinessHealthCheckConfiguration) {
+				if cfg.ReadinessHealthCheckType == nil || *cfg.ReadinessHealthCheckType != "port" {
+					t.Errorf("expected type 'port', got %v", cfg.ReadinessHealthCheckType)
+				}
+				if cfg.ReadinessHealthCheckHTTPEndpoint != nil {
+					t.Errorf("expected nil endpoint for empty value, got %v", *cfg.ReadinessHealthCheckHTTPEndpoint)
+				}
+				if cfg.ReadinessHealthCheckInterval != nil {
+					t.Errorf("expected nil interval for zero value, got %v", *cfg.ReadinessHealthCheckInterval)
+				}
+				if cfg.ReadinessHealthCheckInvocationTimeout != nil {
+					t.Errorf("expected nil timeout for zero value, got %v", *cfg.ReadinessHealthCheckInvocationTimeout)
+				}
+			},
+		},
+		{
+			name: "partial fields set - only interval and timeout",
+			appManifest: &operation.AppManifest{
+				AppManifestProcess: operation.AppManifestProcess{
+					ReadinessHealthCheckInterval:     10,
+					ReadinessHealthInvocationTimeout: 2,
+				},
+			},
+			check: func(t *testing.T, cfg *v1alpha1.ReadinessHealthCheckConfiguration) {
+				if cfg.ReadinessHealthCheckType != nil {
+					t.Errorf("expected nil type for empty value, got %v", *cfg.ReadinessHealthCheckType)
+				}
+				if cfg.ReadinessHealthCheckHTTPEndpoint != nil {
+					t.Errorf("expected nil endpoint for empty value, got %v", *cfg.ReadinessHealthCheckHTTPEndpoint)
+				}
+				if cfg.ReadinessHealthCheckInterval == nil || *cfg.ReadinessHealthCheckInterval != 10 {
+					t.Errorf("expected interval 10, got %v", cfg.ReadinessHealthCheckInterval)
+				}
+				if cfg.ReadinessHealthCheckInvocationTimeout == nil || *cfg.ReadinessHealthCheckInvocationTimeout != 2 {
+					t.Errorf("expected timeout 2, got %v", cfg.ReadinessHealthCheckInvocationTimeout)
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := convertReadinessHealthCheckConfiguration(tt.appManifest)
+			if tt.check != nil {
+				tt.check(t, result)
+			}
+		})
+	}
+}
+
 // Note: convertAppResource is tested through integration-style tests
 // since it calls getAppManifest which makes external API calls.
-// The helper functions (convertDockerField, convertProcessesField) are
-// unit tested above.
+// The helper functions (convertDockerField, convertProcessesField, convertProcessConfiguration,
+// convertReadinessHealthCheckConfiguration) are unit tested above.

--- a/cmd/exporter/cf/app/convert_test.go
+++ b/cmd/exporter/cf/app/convert_test.go
@@ -1,0 +1,344 @@
+/*
+Copyright 2025 SAP SE.
+*/
+
+package app
+
+import (
+	"testing"
+
+	"github.com/SAP/crossplane-provider-cloudfoundry/apis/resources/v1alpha1"
+
+	"github.com/SAP/xp-clifford/yaml"
+	"github.com/cloudfoundry/go-cfclient/v3/operation"
+	"github.com/cloudfoundry/go-cfclient/v3/resource"
+	cpresource "github.com/crossplane/crossplane-runtime/pkg/resource"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+)
+
+// mockEventHandler is a test double for export.EventHandler
+type mockEventHandler struct {
+	warnings  []error
+	resources []cpresource.Object
+}
+
+func (m *mockEventHandler) Warn(err error) {
+	m.warnings = append(m.warnings, err)
+}
+
+func (m *mockEventHandler) Resource(r cpresource.Object) {
+	m.resources = append(m.resources, r)
+}
+
+func (m *mockEventHandler) Stop() {}
+
+// createTestApp creates a test app resource for unit tests
+func createTestApp(name, guid, spaceGUID, lifecycle string) *res {
+	return &res{
+		App: &resource.App{
+			Name: name,
+			Resource: resource.Resource{
+				GUID: guid,
+			},
+			Lifecycle: resource.Lifecycle{
+				Type: lifecycle,
+			},
+			Relationships: resource.AppRelationships{
+				Space: resource.ToOneRelationship{
+					Data: &resource.Relationship{
+						GUID: spaceGUID,
+					},
+				},
+			},
+		},
+		ResourceWithComment: yaml.NewResourceWithComment(nil),
+	}
+}
+
+func TestConvertDockerField(t *testing.T) {
+	type args struct {
+		app         *res
+		managedApp  *v1alpha1.App
+		appManifest *operation.AppManifest
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+		check   func(t *testing.T, managedApp *v1alpha1.App)
+	}{
+		{
+			name: "docker image without credentials",
+			args: args{
+				app:        createTestApp("test-app", "guid-1", "space-guid", "docker"),
+				managedApp: &v1alpha1.App{},
+				appManifest: &operation.AppManifest{
+					Docker: &operation.AppManifestDocker{
+						Image: "nginx:latest",
+					},
+				},
+			},
+			wantErr: false,
+			check: func(t *testing.T, managedApp *v1alpha1.App) {
+				if managedApp.Spec.ForProvider.Docker == nil {
+					t.Errorf("expected Docker config to be set")
+					return
+				}
+				if managedApp.Spec.ForProvider.Docker.Image != "nginx:latest" {
+					t.Errorf("expected Docker image to be 'nginx:latest', got %s", managedApp.Spec.ForProvider.Docker.Image)
+				}
+				if managedApp.Spec.ForProvider.Docker.Credentials != nil {
+					t.Errorf("expected no credentials when username is empty")
+				}
+			},
+		},
+		{
+			name: "docker image with credentials",
+			args: args{
+				app:        createTestApp("test-app", "guid-1", "space-guid", "docker"),
+				managedApp: &v1alpha1.App{},
+				appManifest: &operation.AppManifest{
+					Docker: &operation.AppManifestDocker{
+						Image:    "private.registry.com/app:1.0",
+						Username: "myuser",
+					},
+				},
+			},
+			wantErr: false,
+			check: func(t *testing.T, managedApp *v1alpha1.App) {
+				if managedApp.Spec.ForProvider.Docker == nil {
+					t.Errorf("expected Docker config to be set")
+					return
+				}
+				if managedApp.Spec.ForProvider.Docker.Image != "private.registry.com/app:1.0" {
+					t.Errorf("expected Docker image to be 'private.registry.com/app:1.0', got %s", managedApp.Spec.ForProvider.Docker.Image)
+				}
+				if managedApp.Spec.ForProvider.Docker.Credentials == nil {
+					t.Errorf("expected credentials to be set")
+					return
+				}
+				if managedApp.Spec.ForProvider.Docker.Credentials.Name == "" {
+					t.Errorf("expected secret name to be set")
+				}
+			},
+		},
+		{
+			name: "missing docker configuration in manifest",
+			args: args{
+				app:         createTestApp("test-app", "guid-1", "space-guid", "docker"),
+				managedApp:  &v1alpha1.App{},
+				appManifest: &operation.AppManifest{},
+			},
+			wantErr: true,
+			check: func(t *testing.T, managedApp *v1alpha1.App) {
+				if managedApp.Spec.ForProvider.Docker != nil {
+					t.Errorf("expected Docker config to be nil when error occurs")
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockHandler := &mockEventHandler{}
+			err := convertDockerField(tt.args.app, tt.args.managedApp, tt.args.appManifest, mockHandler)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("convertDockerField() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.check != nil {
+				tt.check(t, tt.args.managedApp)
+			}
+		})
+	}
+}
+
+func TestConvertProcessesField(t *testing.T) {
+	type args struct {
+		managedApp  *v1alpha1.App
+		appManifest *operation.AppManifest
+	}
+	tests := []struct {
+		name  string
+		args  args
+		check func(t *testing.T, managedApp *v1alpha1.App)
+	}{
+		{
+			name: "nil processes",
+			args: args{
+				managedApp:  &v1alpha1.App{},
+				appManifest: &operation.AppManifest{},
+			},
+			check: func(t *testing.T, managedApp *v1alpha1.App) {
+				if len(managedApp.Spec.ForProvider.Processes) != 0 {
+					t.Errorf("expected no processes, got %d", len(managedApp.Spec.ForProvider.Processes))
+				}
+			},
+		},
+		{
+			name: "empty processes",
+			args: args{
+				managedApp: &v1alpha1.App{},
+				appManifest: &operation.AppManifest{
+					Processes: &operation.AppManifestProcesses{},
+				},
+			},
+			check: func(t *testing.T, managedApp *v1alpha1.App) {
+				if len(managedApp.Spec.ForProvider.Processes) != 0 {
+					t.Errorf("expected no processes, got %d", len(managedApp.Spec.ForProvider.Processes))
+				}
+			},
+		},
+		{
+			name: "single web process",
+			args: args{
+				managedApp: &v1alpha1.App{},
+				appManifest: &operation.AppManifest{
+					Processes: &operation.AppManifestProcesses{
+						{
+							Type:                         "web",
+							Command:                      "node server.js",
+							DiskQuota:                    "1G",
+							Instances:                    ptr.To[uint](2),
+							Memory:                       "512M",
+							Timeout:                      60,
+							HealthCheckType:              "http",
+							HealthCheckHTTPEndpoint:      "/health",
+							HealthCheckInterval:          30,
+							HealthCheckInvocationTimeout: 5,
+						},
+					},
+				},
+			},
+			check: func(t *testing.T, managedApp *v1alpha1.App) {
+				if len(managedApp.Spec.ForProvider.Processes) != 1 {
+					t.Errorf("expected 1 process, got %d", len(managedApp.Spec.ForProvider.Processes))
+					return
+				}
+				p := managedApp.Spec.ForProvider.Processes[0]
+				if *p.Type != "web" {
+					t.Errorf("expected type 'web', got %s", *p.Type)
+				}
+				if *p.Command != "node server.js" {
+					t.Errorf("expected command 'node server.js', got %s", *p.Command)
+				}
+				if *p.DiskQuota != "1G" {
+					t.Errorf("expected disk quota '1G', got %s", *p.DiskQuota)
+				}
+				if *p.Instances != 2 {
+					t.Errorf("expected 2 instances, got %d", *p.Instances)
+				}
+				if *p.Memory != "512M" {
+					t.Errorf("expected memory '512M', got %s", *p.Memory)
+				}
+				if *p.Timeout != 60 {
+					t.Errorf("expected timeout 60, got %d", *p.Timeout)
+				}
+				if *p.HealthCheckType != "http" {
+					t.Errorf("expected health check type 'http', got %s", *p.HealthCheckType)
+				}
+				if *p.HealthCheckHTTPEndpoint != "/health" {
+					t.Errorf("expected health check endpoint '/health', got %s", *p.HealthCheckHTTPEndpoint)
+				}
+				if *p.HealthCheckInterval != 30 {
+					t.Errorf("expected health check interval 30, got %d", *p.HealthCheckInterval)
+				}
+				if *p.HealthCheckInvocationTimeout != 5 {
+					t.Errorf("expected health check invocation timeout 5, got %d", *p.HealthCheckInvocationTimeout)
+				}
+			},
+		},
+		{
+			name: "multiple processes",
+			args: args{
+				managedApp: &v1alpha1.App{},
+				appManifest: &operation.AppManifest{
+					Processes: &operation.AppManifestProcesses{
+						{
+							Type:      "web",
+							Command:   "node server.js",
+							Instances: ptr.To[uint](2),
+							Memory:    "512M",
+						},
+						{
+							Type:      "worker",
+							Command:   "node worker.js",
+							Instances: ptr.To[uint](1),
+							Memory:    "256M",
+						},
+					},
+				},
+			},
+			check: func(t *testing.T, managedApp *v1alpha1.App) {
+				if len(managedApp.Spec.ForProvider.Processes) != 2 {
+					t.Errorf("expected 2 processes, got %d", len(managedApp.Spec.ForProvider.Processes))
+					return
+				}
+				if *managedApp.Spec.ForProvider.Processes[0].Type != "web" {
+					t.Errorf("expected first process type 'web', got %s", *managedApp.Spec.ForProvider.Processes[0].Type)
+				}
+				if *managedApp.Spec.ForProvider.Processes[1].Type != "worker" {
+					t.Errorf("expected second process type 'worker', got %s", *managedApp.Spec.ForProvider.Processes[1].Type)
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			convertProcessesField(tt.args.managedApp, tt.args.appManifest)
+			if tt.check != nil {
+				tt.check(t, tt.args.managedApp)
+			}
+		})
+	}
+}
+
+func TestGenerateDockerCredentialSecret(t *testing.T) {
+	tests := []struct {
+		name       string
+		secretName string
+		username   string
+		check      func(t *testing.T, secret *yaml.ResourceWithComment)
+	}{
+		{
+			name:       "basic secret generation",
+			secretName: "myapp-docker-credentials",
+			username:   "dockeruser",
+			check: func(t *testing.T, secretWithComment *yaml.ResourceWithComment) {
+				secret, ok := secretWithComment.Resource().(*v1.Secret)
+				if !ok {
+					t.Fatalf("expected *v1.Secret, got %T", secretWithComment.Resource())
+				}
+				if secret.Name != "myapp-docker-credentials" {
+					t.Errorf("expected name 'myapp-docker-credentials', got %s", secret.Name)
+				}
+				if secret.Type != v1.SecretTypeOpaque {
+					t.Errorf("expected type Opaque, got %s", secret.Type)
+				}
+				if secret.StringData["username"] != "dockeruser" {
+					t.Errorf("expected username 'dockeruser', got %s", secret.StringData["username"])
+				}
+				if secret.StringData["password"] != "TODO" {
+					t.Errorf("expected password placeholder 'TODO', got %s", secret.StringData["password"])
+				}
+				// Check comment was added
+				if comment, _ := secretWithComment.Comment(); comment == "" {
+					t.Errorf("expected comment to be added to secret")
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			secret := generateDockerCredentialSecret(tt.secretName, tt.username)
+			if tt.check != nil {
+				tt.check(t, secret)
+			}
+		})
+	}
+}
+
+// Note: convertAppResource is tested through integration-style tests
+// since it calls getAppManifest which makes external API calls.
+// The helper functions (convertDockerField, convertProcessesField) are
+// unit tested above.

--- a/cmd/exporter/cf/app/convert_test.go
+++ b/cmd/exporter/cf/app/convert_test.go
@@ -327,6 +327,63 @@ func TestGenerateDockerCredentialSecret(t *testing.T) {
 				}
 			},
 		},
+		{
+			name:       "empty username",
+			secretName: "myapp-docker-credentials",
+			username:   "",
+			check: func(t *testing.T, secretWithComment *yaml.ResourceWithComment) {
+				secret, ok := secretWithComment.Resource().(*v1.Secret)
+				if !ok {
+					t.Fatalf("expected *v1.Secret, got %T", secretWithComment.Resource())
+				}
+				if secret.Name != "myapp-docker-credentials" {
+					t.Errorf("expected name 'myapp-docker-credentials', got %s", secret.Name)
+				}
+				if secret.StringData["username"] != "" {
+					t.Errorf("expected empty username, got %s", secret.StringData["username"])
+				}
+				if secret.StringData["password"] != "TODO" {
+					t.Errorf("expected password placeholder 'TODO', got %s", secret.StringData["password"])
+				}
+			},
+		},
+		{
+			name:       "empty secret name",
+			secretName: "",
+			username:   "dockeruser",
+			check: func(t *testing.T, secretWithComment *yaml.ResourceWithComment) {
+				secret, ok := secretWithComment.Resource().(*v1.Secret)
+				if !ok {
+					t.Fatalf("expected *v1.Secret, got %T", secretWithComment.Resource())
+				}
+				if secret.Name != "" {
+					t.Errorf("expected empty secret name, got %s", secret.Name)
+				}
+				if secret.StringData["username"] != "dockeruser" {
+					t.Errorf("expected username 'dockeruser', got %s", secret.StringData["username"])
+				}
+			},
+		},
+		{
+			name:       "both empty",
+			secretName: "",
+			username:   "",
+			check: func(t *testing.T, secretWithComment *yaml.ResourceWithComment) {
+				secret, ok := secretWithComment.Resource().(*v1.Secret)
+				if !ok {
+					t.Fatalf("expected *v1.Secret, got %T", secretWithComment.Resource())
+				}
+				if secret.Name != "" {
+					t.Errorf("expected empty secret name, got %s", secret.Name)
+				}
+				if secret.StringData["username"] != "" {
+					t.Errorf("expected empty username, got %s", secret.StringData["username"])
+				}
+				if secret.StringData["password"] != "TODO" {
+					t.Errorf("expected password placeholder 'TODO', got %s", secret.StringData["password"])
+				}
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/exporter/cf/app/manifest.go
+++ b/cmd/exporter/cf/app/manifest.go
@@ -1,0 +1,55 @@
+package app
+
+import (
+	"context"
+	"log/slog"
+
+	// kyaml "sigs.k8s.io/yaml"
+	gyaml "gopkg.in/yaml.v2"
+
+	"github.com/SAP/xp-clifford/erratt"
+
+	"github.com/cloudfoundry/go-cfclient/v3/client"
+	"github.com/cloudfoundry/go-cfclient/v3/operation"
+)
+
+// type docker struct {
+// 	Image string `json:"image"`
+// 	Username *string `json:"username,omitempty"`
+// }
+
+// type application struct {
+// 	Name string `json:"name"`
+// 	Docker *docker `json:"docker,omitempty"`
+// }
+
+// type manifest struct {
+// 	Applications []application `json:"applications"`
+// }
+
+func getManifest(ctx context.Context, cfClient *client.Client, appGUID string) (*operation.Manifest, error) {
+	m := &operation.Manifest{}
+	stringManifest, err := cfClient.Manifests.Generate(ctx, appGUID)
+	if err != nil {
+		return nil, erratt.Errorf("cannot generate app manifest: %w", err).With("GUID", appGUID)
+	}
+
+	slog.Debug("manifest fetched", "manifest", stringManifest)
+	err = gyaml.Unmarshal([]byte(stringManifest), m)
+
+	return m, err
+}
+
+func getAppManifest(ctx context.Context, cfClient *client.Client, appGUID string) (*operation.AppManifest, error) {
+	m, err := getManifest(ctx, cfClient, appGUID)
+	if err != nil {
+		return nil, err
+	}
+	if len(m.Applications) == 0 {
+		return nil, nil
+	}
+	if m.Applications[0] == nil {
+		return nil, nil
+	}
+	return m.Applications[0], nil
+}

--- a/cmd/exporter/cf/app/manifest.go
+++ b/cmd/exporter/cf/app/manifest.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"log/slog"
 
-	// kyaml "sigs.k8s.io/yaml"
 	gyaml "gopkg.in/yaml.v2"
 
 	"github.com/SAP/xp-clifford/erratt"
@@ -13,20 +12,6 @@ import (
 	"github.com/cloudfoundry/go-cfclient/v3/client"
 	"github.com/cloudfoundry/go-cfclient/v3/operation"
 )
-
-// type docker struct {
-// 	Image string `json:"image"`
-// 	Username *string `json:"username,omitempty"`
-// }
-
-// type application struct {
-// 	Name string `json:"name"`
-// 	Docker *docker `json:"docker,omitempty"`
-// }
-
-// type manifest struct {
-// 	Applications []application `json:"applications"`
-// }
 
 // getManifest fetches the application manifest from Cloud Foundry API for the given app GUID.
 // Returns the parsed manifest containing all application configurations.

--- a/cmd/exporter/cf/app/manifest.go
+++ b/cmd/exporter/cf/app/manifest.go
@@ -1,3 +1,4 @@
+// Package app implements Cloud Foundry App resource export functionality.
 package app
 
 import (
@@ -27,6 +28,8 @@ import (
 // 	Applications []application `json:"applications"`
 // }
 
+// getManifest fetches the application manifest from Cloud Foundry API for the given app GUID.
+// Returns the parsed manifest containing all application configurations.
 func getManifest(ctx context.Context, cfClient *client.Client, appGUID string) (*operation.Manifest, error) {
 	m := &operation.Manifest{}
 	stringManifest, err := cfClient.Manifests.Generate(ctx, appGUID)
@@ -40,6 +43,8 @@ func getManifest(ctx context.Context, cfClient *client.Client, appGUID string) (
 	return m, err
 }
 
+// getAppManifest retrieves the first application manifest from the CF API response.
+// Returns nil if no applications are found in the manifest.
 func getAppManifest(ctx context.Context, cfClient *client.Client, appGUID string) (*operation.AppManifest, error) {
 	m, err := getManifest(ctx, cfClient, appGUID)
 	if err != nil {

--- a/cmd/exporter/cf/app/secret.go
+++ b/cmd/exporter/cf/app/secret.go
@@ -1,0 +1,28 @@
+package app
+
+import (
+	"github.com/SAP/xp-clifford/yaml"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func generateDockerCredentialSecret(name, username string) *yaml.ResourceWithComment {
+	s := &v1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		StringData: map[string]string{
+			"username": username,
+			"password": "TODO",
+		},
+		Type: v1.SecretTypeOpaque,
+	}
+	s.SetName(name)
+	commentedSecret := yaml.NewResourceWithComment(s)
+	commentedSecret.AddComment("Cannot export the password value. Fill in the password field manually.")
+	return commentedSecret
+}

--- a/cmd/exporter/cf/app/secret.go
+++ b/cmd/exporter/cf/app/secret.go
@@ -1,3 +1,4 @@
+// Package app implements Cloud Foundry App resource export functionality.
 package app
 
 import (
@@ -6,6 +7,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// generateDockerCredentialSecret creates a Kubernetes Secret for Docker registry credentials.
+// The password field is set to "TODO" as a placeholder since the actual password cannot be exported.
+// The secret includes a comment reminding users to manually fill in the password.
 func generateDockerCredentialSecret(name, username string) *yaml.ResourceWithComment {
 	s := &v1.Secret{
 		TypeMeta: metav1.TypeMeta{

--- a/cmd/exporter/cf/serviceinstance/convert.go
+++ b/cmd/exporter/cf/serviceinstance/convert.go
@@ -161,7 +161,7 @@ func convertServiceInstanceResource(ctx context.Context, cfClient *client.Client
 
 	if resolveReferences {
 		if err := space.ResolveReference(ctx, cfClient, &managedSI.Spec.ForProvider.SpaceReference); err != nil {
-			erra := erratt.Errorf("cannot resolve space reference: %w", err).With("serviceinstance-name", serviceInstance.GetName)
+			erra := erratt.Errorf("cannot resolve space reference: %w", err).With("serviceinstance-name", serviceInstance.GetName())
 			evHandler.Warn(erra)
 		}
 	}

--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	_ "github.com/SAP/crossplane-provider-cloudfoundry/cmd/exporter/cf/app"
 	_ "github.com/SAP/crossplane-provider-cloudfoundry/cmd/exporter/cf/org"
 	_ "github.com/SAP/crossplane-provider-cloudfoundry/cmd/exporter/cf/orgrole"
 	"github.com/SAP/crossplane-provider-cloudfoundry/cmd/exporter/cf/resources"

--- a/config.nix
+++ b/config.nix
@@ -2,8 +2,8 @@
 {
   exporter-cli = {
     name = "xpcf";
-    version = "0.0.1-alpha1";
-    vendorHash = "sha256-tbxVojTzdbS52myhp7tx8ikxmZuZ0qXRRrt4tGuvHf0=";
+    version = "0.0.1-alpha2";
+    vendorHash = "sha256-CHnwyDp1gZBZ8jkEeMSZ3lo3jkY6YPnbodLUsWbIEOo=";
     # vendorHash = lib.fakeHash;
     meta = {
       description = "xpcf is a CLI tool for exporting existing resources as Crossplane managed resources";

--- a/config.nix
+++ b/config.nix
@@ -3,7 +3,7 @@
   exporter-cli = {
     name = "xpcf";
     version = "0.0.1-alpha1";
-    vendorHash = "sha256-FlLcWkMMaR7UHfnIXWbMBkBTSsgwPdyIatoZ0upmTgM=";
+    vendorHash = "sha256-tbxVojTzdbS52myhp7tx8ikxmZuZ0qXRRrt4tGuvHf0=";
     # vendorHash = lib.fakeHash;
     meta = {
       description = "xpcf is a CLI tool for exporting existing resources as Crossplane managed resources";

--- a/config.nix
+++ b/config.nix
@@ -3,7 +3,7 @@
   exporter-cli = {
     name = "xpcf";
     version = "0.0.1-alpha2";
-    vendorHash = "sha256-CHnwyDp1gZBZ8jkEeMSZ3lo3jkY6YPnbodLUsWbIEOo=";
+    vendorHash = "sha256-CayeW853k8NLFtvC/8S/MkW1gaUSOS3ftBRfSh5OhS0=";
     # vendorHash = lib.fakeHash;
     meta = {
       description = "xpcf is a CLI tool for exporting existing resources as Crossplane managed resources";

--- a/docs/end-user-guides/import-resources-provider-cf.mdx
+++ b/docs/end-user-guides/import-resources-provider-cf.mdx
@@ -267,7 +267,7 @@ When set, the `verbose` configuration parameter enables printing of *debug-level
 
 ### Login
 
-The `login` subcommand saves the [API URL](#api-url), [username](#username), and [password](#password) configuration values to the config file.
+The `login` subcommand saves the [API URL](#apiurl), [username](#username), and [password](#password) configuration values to the config file.
 
 For examples refer to [workflows chapter](#logging-in-using-username-and-password).
 
@@ -290,9 +290,9 @@ There are various ways to configure the authentication parameters in `xpcf`.
 
 The simplest approach is to use the `cf` CLI tool's<sup><a id="fnr.2" class="footref" href="#fn.2" role="doc-backlink">2</a></sup> `login` subcommand<sup><a id="fnr.3" class="footref" href="#fn.3" role="doc-backlink">3</a></sup>. This creates a configuration file with the *Cloud Foundry* API credentials, which can be reused by `xpcf` through the [`use-cf-login`](#use-cf-login) configuration parameter. See [use-cf-login](#use-cf-login) for details.
 
-The [API URL](#api-url), [username](#username), and [password](#password) for the *Cloud Foundry* environment can also be specified using configuration parameters via CLI flags, environment variables, or the configuration file.
+The [API URL](#apiurl), [username](#username), and [password](#password) for the *Cloud Foundry* environment can also be specified using configuration parameters via CLI flags, environment variables, or the configuration file.
 
-The `login` subcommand can be used to update the configuration file with the [API URL](#api-url), [username](#username), and [password](#password) values.
+The `login` subcommand can be used to update the configuration file with the [API URL](#apiurl), [username](#username), and [password](#password) values.
 
 
 <a id="apiurl"></a>
@@ -336,7 +336,7 @@ This configuration parameter specifies the password for authenticating with the 
 
 #### Configuration Parameters
 
-The `export` subcommand can be configured using the [API URL](#api-url), [username](#username), and [password](#password) configuration parameters. These parameters allow you to define the authentication details for the Cloud Foundry cluster from which resources are exported.
+The `export` subcommand can be configured using the [API URL](#apiurl), [username](#username), and [password](#password) configuration parameters. These parameters allow you to define the authentication details for the Cloud Foundry cluster from which resources are exported.
 
 Alternatively, it is more convenient to use the [login](#login) subcommand, which persists these parameters in the configuration file so you don't have to specify their values for each command.
 
@@ -462,7 +462,7 @@ When exporting *ServiceInstance* resource kinds, the `serviceinstance` parameter
 
 ## Logging in using username and password
 
-The [export](#export) subcommand accepts the [API URL](#api-url), [username](#username), and [password](#password) configuration parameters for authentication. If you prefer not to specify these parameters for each `export` invocation, you can store them in a [configuration file](#configuration-file).
+The [export](#export) subcommand accepts the [API URL](#apiurl), [username](#username), and [password](#password) configuration parameters for authentication. If you prefer not to specify these parameters for each `export` invocation, you can store them in a [configuration file](#configuration-file).
 
 The [login](#login) subcommand simplifies this process.
 
@@ -506,7 +506,7 @@ xpcf export --use-cf-login
 
 To export *Organization* resources, configure the following:
 
--   The credentials and API URL of the Cloud Foundry cluster ([username](#username), [password](#password), [apiurl](#api-url))
+-   The credentials and API URL of the Cloud Foundry cluster ([username](#username), [password](#password), [apiurl](#apiurl))
 -   The resource kind to export, which should be set to `organization` ([kind](#kind))
 -   A regular expression matching the organization name(s) to export ([org](#org))
 
@@ -523,7 +523,7 @@ The *Organization* names are selected interactively.
 
 This example demonstrates non-interactive export of all *Spaces* from all *Organizations*. Configure the following:
 
--   The credentials and API URL of the Cloud Foundry cluster ([username](#username), [password](#password), [apiurl](#api-url))
+-   The credentials and API URL of the Cloud Foundry cluster ([username](#username), [password](#password), [apiurl](#apiurl))
 -   The resource kind to export, which should be set to `space` ([kind](#kind))
 -   A regular expression matching the organization name(s) to include ([org](#org))
 -   A regular expression matching the space name(s) to include ([space](#space))
@@ -547,7 +547,7 @@ This example shows how to export all *ServiceInstance* resources from spaces con
 
 Configure the following:
 
--   The credentials and API URL of the Cloud Foundry cluster ([username](#username), [password](#password), [apiurl](#api-url))
+-   The credentials and API URL of the Cloud Foundry cluster ([username](#username), [password](#password), [apiurl](#apiurl))
 -   The resource kind to export, set to `serviceinstance` ([kind](#kind))
 -   A regular expression matching the organization names to include ([org](#org))
 -   A regular expression matching the space names to include ([space](#space))
@@ -573,7 +573,7 @@ This example shows how to interactively export a specific *ServiceInstance* reso
 
 Configure the following:
 
--   The credentials and API URL of the Cloud Foundry cluster ([username](#username), [password](#password), [apiurl](#api-url))
+-   The credentials and API URL of the Cloud Foundry cluster ([username](#username), [password](#password), [apiurl](#apiurl))
 -   The resource kind to export, set to `serviceinstance` ([kind](#kind))
 -   A regular expression matching the organization names to include ([org](#org))
 -   A regular expression matching the space names to include ([space](#space))

--- a/docs/end-user-guides/import-resources-provider-cf.mdx
+++ b/docs/end-user-guides/import-resources-provider-cf.mdx
@@ -267,7 +267,7 @@ When set, the `verbose` configuration parameter enables printing of *debug-level
 
 ### Login
 
-The `login` subcommand saves the [API URL](#apiurl), [username](#username), and [password](#password) configuration values to the config file.
+The `login` subcommand saves the [API URL](#api-url), [username](#username), and [password](#password) configuration values to the config file.
 
 For examples refer to [workflows chapter](#logging-in-using-username-and-password).
 
@@ -290,9 +290,9 @@ There are various ways to configure the authentication parameters in `xpcf`.
 
 The simplest approach is to use the `cf` CLI tool's<sup><a id="fnr.2" class="footref" href="#fn.2" role="doc-backlink">2</a></sup> `login` subcommand<sup><a id="fnr.3" class="footref" href="#fn.3" role="doc-backlink">3</a></sup>. This creates a configuration file with the *Cloud Foundry* API credentials, which can be reused by `xpcf` through the [`use-cf-login`](#use-cf-login) configuration parameter. See [use-cf-login](#use-cf-login) for details.
 
-The [API URL](#apiurl), [username](#username), and [password](#password) for the *Cloud Foundry* environment can also be specified using configuration parameters via CLI flags, environment variables, or the configuration file.
+The [API URL](#api-url), [username](#username), and [password](#password) for the *Cloud Foundry* environment can also be specified using configuration parameters via CLI flags, environment variables, or the configuration file.
 
-The `login` subcommand can be used to update the configuration file with the [API URL](#apiurl), [username](#username), and [password](#password) values.
+The `login` subcommand can be used to update the configuration file with the [API URL](#api-url), [username](#username), and [password](#password) values.
 
 
 <a id="apiurl"></a>
@@ -336,7 +336,7 @@ This configuration parameter specifies the password for authenticating with the 
 
 #### Configuration Parameters
 
-The `export` subcommand can be configured using the [API URL](#apiurl), [username](#username), and [password](#password) configuration parameters. These parameters allow you to define the authentication details for the Cloud Foundry cluster from which resources are exported.
+The `export` subcommand can be configured using the [API URL](#api-url), [username](#username), and [password](#password) configuration parameters. These parameters allow you to define the authentication details for the Cloud Foundry cluster from which resources are exported.
 
 Alternatively, it is more convenient to use the [login](#login) subcommand, which persists these parameters in the configuration file so you don't have to specify their values for each command.
 
@@ -462,7 +462,7 @@ When exporting *ServiceInstance* resource kinds, the `serviceinstance` parameter
 
 ## Logging in using username and password
 
-The [export](#export) subcommand accepts the [API URL](#apiurl), [username](#username), and [password](#password) configuration parameters for authentication. If you prefer not to specify these parameters for each `export` invocation, you can store them in a [configuration file](#configuration-file).
+The [export](#export) subcommand accepts the [API URL](#api-url), [username](#username), and [password](#password) configuration parameters for authentication. If you prefer not to specify these parameters for each `export` invocation, you can store them in a [configuration file](#configuration-file).
 
 The [login](#login) subcommand simplifies this process.
 
@@ -506,7 +506,7 @@ xpcf export --use-cf-login
 
 To export *Organization* resources, configure the following:
 
--   The credentials and API URL of the Cloud Foundry cluster ([username](#username), [password](#password), [apiurl](#apiurl))
+-   The credentials and API URL of the Cloud Foundry cluster ([username](#username), [password](#password), [apiurl](#api-url))
 -   The resource kind to export, which should be set to `organization` ([kind](#kind))
 -   A regular expression matching the organization name(s) to export ([org](#org))
 
@@ -523,7 +523,7 @@ The *Organization* names are selected interactively.
 
 This example demonstrates non-interactive export of all *Spaces* from all *Organizations*. Configure the following:
 
--   The credentials and API URL of the Cloud Foundry cluster ([username](#username), [password](#password), [apiurl](#apiurl))
+-   The credentials and API URL of the Cloud Foundry cluster ([username](#username), [password](#password), [apiurl](#api-url))
 -   The resource kind to export, which should be set to `space` ([kind](#kind))
 -   A regular expression matching the organization name(s) to include ([org](#org))
 -   A regular expression matching the space name(s) to include ([space](#space))
@@ -547,7 +547,7 @@ This example shows how to export all *ServiceInstance* resources from spaces con
 
 Configure the following:
 
--   The credentials and API URL of the Cloud Foundry cluster ([username](#username), [password](#password), [apiurl](#apiurl))
+-   The credentials and API URL of the Cloud Foundry cluster ([username](#username), [password](#password), [apiurl](#api-url))
 -   The resource kind to export, set to `serviceinstance` ([kind](#kind))
 -   A regular expression matching the organization names to include ([org](#org))
 -   A regular expression matching the space names to include ([space](#space))
@@ -573,7 +573,7 @@ This example shows how to interactively export a specific *ServiceInstance* reso
 
 Configure the following:
 
--   The credentials and API URL of the Cloud Foundry cluster ([username](#username), [password](#password), [apiurl](#apiurl))
+-   The credentials and API URL of the Cloud Foundry cluster ([username](#username), [password](#password), [apiurl](#api-url))
 -   The resource kind to export, set to `serviceinstance` ([kind](#kind))
 -   A regular expression matching the organization names to include ([org](#org))
 -   A regular expression matching the space names to include ([space](#space))
@@ -596,14 +596,14 @@ This example shows how to export all *App* resources from spaces with names cont
 
 Configure the following:
 
--   The credentials and API URL of the Cloud Foundry cluster ([username](#username), [password](#password), [apiurl](#apiurl))
+-   The credentials and API URL of the Cloud Foundry cluster ([username](#username), [password](#password), [apiurl](#api-url))
 -   The resource kind to export, set to `app` ([kind](#kind))
 -   A regular expression matching the organization names to include ([org](#org))
 -   A regular expression matching the space names to include ([space](#space))
 -   A regular expression matching the app names to include ([app](#app))
 -   The resolve references setting ([resolve-references](#resolve-references))
 
-In this example, the export tool retrieves the `username`, `password`, and `apiurl` parameters from the configuration file, as set by the [login](#login-workflows) command.
+In this example, the export tool retrieves the `username`, `password`, and `apiurl` parameters from the configuration file, as set by the [login](#logging-in-using-username-and-password) command.
 
 The `kind`, `org`, `space`, `app`, and `resolve-references` configuration parameters are set using CLI flags.
 

--- a/docs/end-user-guides/import-resources-provider-cf.mdx
+++ b/docs/end-user-guides/import-resources-provider-cf.mdx
@@ -370,6 +370,7 @@ Specifies the resource kinds to export. If not set, the user is prompted interac
 
 The possible values are:
 
+-   `app`
 -   `organization`
 -   `orgrole`
 -   `serviceinstance`
@@ -428,6 +429,18 @@ When exporting *Organization* resource kinds, the `org` parameter value specifie
 
 When exporting *Space* resource kinds, the `space` parameter value specifies regular expressions that the *Space* names must match.
 
+
+<a id="app"></a>
+
+##### App
+
+| Type                 | []string |
+|-------------------- |--------- |
+| CLI flag             | `--app`   |
+| Environment variable | -         |
+| Config file key      | `app`     |
+
+When exporting *App* resource kinds, the `app` parameter value specifies regular expressions that the *App* names must match. Apps can be filtered by organization (`--org`) and space (`--space`) parameters.
 
 <a id="serviceinstance"></a>
 
@@ -575,6 +588,32 @@ The `kind`, `resolve-references`, and `output` configuration parameters are set 
 The `org`, `space`, and `serviceinstance` parameter values are entered interactively.
 
 ![img](/img/cf-export-sis-interactive.gif "Exporting an interactively selected ServiceInstance resource")
+
+
+## Exporting all *Apps* from spaces matching a regex
+
+This example shows how to export all *App* resources from spaces with names containing the word *production*. It demonstrates resolving space references by name.
+
+Configure the following:
+
+-   The credentials and API URL of the Cloud Foundry cluster ([username](#username), [password](#password), [apiurl](#apiurl))
+-   The resource kind to export, set to `app` ([kind](#kind))
+-   A regular expression matching the organization names to include ([org](#org))
+-   A regular expression matching the space names to include ([space](#space))
+-   A regular expression matching the app names to include ([app](#app))
+-   The resolve references setting ([resolve-references](#resolve-references))
+
+In this example, the export tool retrieves the `username`, `password`, and `apiurl` parameters from the configuration file, as set by the [login](#login-workflows) command.
+
+The `kind`, `org`, `space`, `app`, and `resolve-references` configuration parameters are set using CLI flags.
+
+The regular expression `.*` matches all names. The regular expression `.*production.*` matches names containing the string *production*.
+
+The following command exports the required resources:
+
+```bash
+xpcf export --kind app --org '.*' --space '.*production.*' --app '.*' -r
+```
 
 
 # Troubleshooting

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1772408722,
-        "narHash": "sha256-rHuJtdcOjK7rAHpHphUb1iCvgkU3GpfvicLMwwnfMT0=",
+        "lastModified": 1775087534,
+        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f20dc5d9b8027381c474144ecabc9034d6a839a3",
+        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1772198003,
-        "narHash": "sha256-I45esRSssFtJ8p/gLHUZ1OUaaTaVLluNkABkk6arQwE=",
+        "lastModified": 1776877367,
+        "narHash": "sha256-EHq1/OX139R1RvBzOJ0aMRT3xnWyqtHBRUBuO1gFzjI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dd9b079222d43e1943b6ebd802f04fd959dc8e61",
+        "rev": "0726a0ecb6d4e08f6adced58726b95db924cef57",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1772328832,
-        "narHash": "sha256-e+/T/pmEkLP6BHhYjx6GmwP5ivonQQn0bJdH9YrRB+Q=",
+        "lastModified": 1774748309,
+        "narHash": "sha256-+U7gF3qxzwD5TZuANzZPeJTZRHS29OFQgkQ2kiTJBIQ=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "c185c7a5e5dd8f9add5b2f8ebeff00888b070742",
+        "rev": "333c4e0545a6da976206c74db8773a1645b5870a",
         "type": "github"
       },
       "original": {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/SAP/crossplane-provider-cloudfoundry
 go 1.25.0
 
 require (
-	github.com/SAP/xp-clifford v0.0.0-20260312105548-6c739d63b4f1
+	github.com/SAP/xp-clifford v0.0.0-20260320095944-ad159065df3c
 	github.com/cloudfoundry/go-cfclient/v3 v3.0.0-alpha.12
 	github.com/crossplane-contrib/xp-testing v1.9.0
 	github.com/crossplane/crossplane-runtime v1.20.0

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
-github.com/SAP/xp-clifford v0.0.0-20260312105548-6c739d63b4f1 h1:sO2PQvMR971Aav3UYDh7dsGVUKW75H52Kue2CBtUeUM=
-github.com/SAP/xp-clifford v0.0.0-20260312105548-6c739d63b4f1/go.mod h1:HP/zE+opVZtQIOm5sTG7cy916KDqlW9lW5wzaJFBE3w=
+github.com/SAP/xp-clifford v0.0.0-20260320095944-ad159065df3c h1:+pKJ4Bt2mIxp8WRjX87VUAn4PInRD0xqsAkytYubugY=
+github.com/SAP/xp-clifford v0.0.0-20260320095944-ad159065df3c/go.mod h1:HP/zE+opVZtQIOm5sTG7cy916KDqlW9lW5wzaJFBE3w=
 github.com/alecthomas/assert/v2 v2.7.0 h1:QtqSACNS3tF7oasA8CU6A6sXZSBDqnm7RfpLl9bZqbE=
 github.com/alecthomas/assert/v2 v2.7.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
 github.com/alecthomas/chroma/v2 v2.14.0 h1:R3+wzpnUArGcQz7fCETQBzO5n9IMNi13iIs46aU4V9E=


### PR DESCRIPTION
## Summary

  This PR adds support for exporting Cloud Foundry applications to Crossplane App resources. It enables users to migrate
existing CF apps to Crossplane-managed infrastructure.

  ## Changes

  - **feat(exporter): adding App resource** (`8e47b3e`)
    - Implement `cmd/exporter/cf/app/` package with full App export functionality
    - `app.go`: Core export logic with org/space filtering and name pattern matching
    - `convert.go`: CF App manifest to Crossplane App CR conversion
    - `manifest.go`: CF API manifest fetching and parsing
    - `secret.go`: Docker credential secret generation
    - Register app export in `cmd/exporter/main.go`

  - **test(exporter): add unit tests for convertAppResource helpers** (`32e611b`)
    - `TestConvertDockerField`: Docker config conversion with/without credentials
    - `TestConvertProcessesField`: Process configuration conversion (nil, empty, single, multiple)
    - `TestGenerateDockerCredentialSecret`: Secret generation validation

  - **docs(exporter): add documentation comments to app export package** (`6a413f1`)
    - Package-level documentation
    - Function documentation for all exported and internal functions

  - **chore(clifford): bumping xp-clifford dependency** (`80ee652`)
    - Update `github.com/SAP/xp-clifford` to latest version

  ## Technical Details

  The App exporter:
  - Fetches apps from CF API filtered by org/space GUIDs
  - Supports regex pattern matching for app names
  - Converts CF app manifests to Crossplane App resources
  - Handles Docker lifecycle apps with credential secrets
  - Supports process configuration (web, worker, etc.)
  - Includes health check configuration conversion
  - Resolves space references when `resolveReferences` is enabled

  ## Testing

  - Unit tests added for conversion helper functions
  - All tests pass: `make reviewable` ✅