### PR TITLE
fix: update release version handling in pipeline to use nextVersion i…

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -107,9 +107,9 @@ jobs:
 
       - name: Publish Artifacts to DockerHub
         run: |
-          make xpkg.build PLATFORM=linux_amd64 VERSION=${{ steps.version.outputs.version }} BRANCH_NAME=${GITHUB_REF##*/}
-          make xpkg.build PLATFORM=linux_arm64 VERSION=${{ steps.version.outputs.version }} BRANCH_NAME=${GITHUB_REF##*/}
-          make xpkg.release.publish VERSION=${{ steps.version.outputs.version }}
+          make xpkg.build PLATFORM=linux_amd64 VERSION=${{ github.event.inputs.nextVersion }} BRANCH_NAME=${GITHUB_REF##*/}
+          make xpkg.build PLATFORM=linux_arm64 VERSION=${{ github.event.inputs.nextVersion }} BRANCH_NAME=${GITHUB_REF##*/}
+          make xpkg.release.publish VERSION=${{ github.event.inputs.nextVersion }}
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@9ed2f89a662bf1735a48bc8557fd212fa902bebf # v6.1.0


### PR DESCRIPTION
## Problem
The "Publish Artifacts to DockerHub" step referenced `${{ steps.version.outputs.version }}` which points to a non-existent step, causing `VERSION` to be empty and the build to fail.

## Fix
Replace with `${{ github.event.inputs.nextVersion }}`, consistent with the rest of the workflow.