### PR TITLE
fix: implement retry logic for ServiceCredentialBinding creation attempts

### DIFF
--- a/internal/controller/servicecredentialbinding/controller.go
+++ b/internal/controller/servicecredentialbinding/controller.go
@@ -36,7 +36,6 @@ const (
 	errNewClient             = "cannot create a client for " + externalSystem + ": %w"
 	errWrongCRType           = "managed resource is not a " + resourceType
 	errGet                   = "cannot get " + resourceType + " in " + externalSystem + ": %w"
-	errFind                  = "cannot find " + resourceType + " in " + externalSystem
 	errCreate                = "cannot create " + resourceType + " in " + externalSystem + ": %w"
 	errUpdate                = "cannot update " + resourceType + " in " + externalSystem + ": %w"
 	errDelete                = "cannot delete " + resourceType + " in " + externalSystem + ": %w"
@@ -150,13 +149,7 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 		return managed.ExternalObservation{}, errors.New(errWrongCRType)
 	}
 
-	if getCreateAttempts(cr) >= maxCreateAttempts {
-		// Allow deletion to proceed even when circuit breaker is tripped
-		if !cr.GetDeletionTimestamp().IsZero() {
-			return managed.ExternalObservation{
-				ResourceExists: false, // lets Delete() be called to clean up
-			}, nil
-		}
+	if isCircuitBreakerTripped(cr) {
 		cr.SetConditions(xpv1.Unavailable().WithMessage(
 			fmt.Sprintf("Creation failed after %d attempts. Delete and recreate this resource to retry.", maxCreateAttempts),
 		))
@@ -335,4 +328,10 @@ func incrementCreateAttempts(cr *v1alpha1.ServiceCredentialBinding) {
 
 func resetCreateAttempts(cr *v1alpha1.ServiceCredentialBinding) {
 	meta.RemoveAnnotations(cr, createAttemptsAnnotation)
+}
+
+// isCircuitBreakerTripped returns true if the maximum number of create attempts has been reached.
+// If the resource is being deleted, the circuit breaker is bypassed to allow cleanup.
+func isCircuitBreakerTripped(cr *v1alpha1.ServiceCredentialBinding) bool {
+	return getCreateAttempts(cr) >= maxCreateAttempts && cr.GetDeletionTimestamp().IsZero()
 }

--- a/internal/controller/servicecredentialbinding/controller.go
+++ b/internal/controller/servicecredentialbinding/controller.go
@@ -151,6 +151,12 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 	}
 
 	if getCreateAttempts(cr) >= maxCreateAttempts {
+		// Allow deletion to proceed even when circuit breaker is tripped
+		if !cr.GetDeletionTimestamp().IsZero() {
+			return managed.ExternalObservation{
+				ResourceExists: false, // lets Delete() be called to clean up
+			}, nil
+		}
 		cr.SetConditions(xpv1.Unavailable().WithMessage(
 			fmt.Sprintf("Creation failed after %d attempts. Delete and recreate this resource to retry.", maxCreateAttempts),
 		))

--- a/internal/controller/servicecredentialbinding/controller.go
+++ b/internal/controller/servicecredentialbinding/controller.go
@@ -294,6 +294,11 @@ func (c *external) HandleObservationState(serviceBinding *cfresource.ServiceCred
 		}, nil
 	case v1alpha1.LastOperationSucceeded:
 		resetCreateAttempts(cr)
+
+		if err := c.kube.Update(ctx, cr); err != nil {
+			return managed.ExternalObservation{}, fmt.Errorf("cannot persist create attempt reset: %w", err)
+		}
+
 		cr.SetConditions(xpv1.Available())
 
 		return managed.ExternalObservation{

--- a/internal/controller/servicecredentialbinding/controller.go
+++ b/internal/controller/servicecredentialbinding/controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/connection"
@@ -29,21 +30,23 @@ import (
 )
 
 const (
-	resourceType         = "ServiceCredentialBinding"
-	externalSystem       = "Cloud Foundry"
-	errTrackPCUsage      = "cannot track ProviderConfig usage: %w"
-	errNewClient         = "cannot create a client for " + externalSystem + ": %w"
-	errWrongCRType       = "managed resource is not a " + resourceType
-	errGet               = "cannot get " + resourceType + " in " + externalSystem + ": %w"
-	errFind              = "cannot find " + resourceType + " in " + externalSystem
-	errCreate            = "cannot create " + resourceType + " in " + externalSystem + ": %w"
-	errUpdate            = "cannot update " + resourceType + " in " + externalSystem + ": %w"
-	errDelete            = "cannot delete " + resourceType + " in " + externalSystem + ": %w"
-	errDeleteRetiredKeys = "cannot delete retired keys in " + externalSystem + ": %w"
-	errDeleteExpiredKeys = "cannot delete expired keys in " + externalSystem + ": %w"
-	errUpdateStatus      = "cannot update status after retiring binding: %w"
-	errExtractParams     = "cannot extract specified parameters: %w"
-	errUnknownState      = "unknown last operation state for " + resourceType + " in " + externalSystem
+	resourceType             = "ServiceCredentialBinding"
+	externalSystem           = "Cloud Foundry"
+	errTrackPCUsage          = "cannot track ProviderConfig usage: %w"
+	errNewClient             = "cannot create a client for " + externalSystem + ": %w"
+	errWrongCRType           = "managed resource is not a " + resourceType
+	errGet                   = "cannot get " + resourceType + " in " + externalSystem + ": %w"
+	errFind                  = "cannot find " + resourceType + " in " + externalSystem
+	errCreate                = "cannot create " + resourceType + " in " + externalSystem + ": %w"
+	errUpdate                = "cannot update " + resourceType + " in " + externalSystem + ": %w"
+	errDelete                = "cannot delete " + resourceType + " in " + externalSystem + ": %w"
+	errDeleteRetiredKeys     = "cannot delete retired keys in " + externalSystem + ": %w"
+	errDeleteExpiredKeys     = "cannot delete expired keys in " + externalSystem + ": %w"
+	errUpdateStatus          = "cannot update status after retiring binding: %w"
+	errExtractParams         = "cannot extract specified parameters: %w"
+	errUnknownState          = "unknown last operation state for " + resourceType + " in " + externalSystem
+	maxCreateAttempts        = 5
+	createAttemptsAnnotation = "crossplane-provider-cloudfoundry/create-attempts"
 )
 
 // Setup adds a controller that reconciles ServiceCredentialBinding CR.
@@ -147,6 +150,16 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 		return managed.ExternalObservation{}, errors.New(errWrongCRType)
 	}
 
+	if getCreateAttempts(cr) >= maxCreateAttempts {
+		cr.SetConditions(xpv1.Unavailable().WithMessage(
+			fmt.Sprintf("Creation failed after %d attempts. Delete and recreate this resource to retry.", maxCreateAttempts),
+		))
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
+
 	guid := meta.GetExternalName(cr)
 	serviceBinding, err := scb.GetByIDOrSearch(ctx, c.scbClient, guid, cr.Spec.ForProvider)
 	if errors.Is(err, cfclient.ErrNoResultsReturned) ||
@@ -178,6 +191,11 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 	cr, ok := mg.(*v1alpha1.ServiceCredentialBinding)
 	if !ok {
 		return managed.ExternalCreation{}, errors.New(errWrongCRType)
+	}
+
+	incrementCreateAttempts(cr)
+	if err := c.kube.Update(ctx, cr); err != nil {
+		return managed.ExternalCreation{}, fmt.Errorf("cannot persist create attempt count: %w", err)
 	}
 
 	params, err := extractParameters(ctx, c.kube, cr.Spec.ForProvider)
@@ -272,10 +290,11 @@ func (c *external) HandleObservationState(serviceBinding *cfresource.ServiceCred
 	case v1alpha1.LastOperationFailed:
 		cr.SetConditions(xpv1.Unavailable().WithMessage(serviceBinding.LastOperation.Description))
 		return managed.ExternalObservation{
-			ResourceExists:   serviceBinding.LastOperation.Type != v1alpha1.LastOperationCreate, // set to false when the last operation is create, hence the reconciler will retry create
+			ResourceExists:   true,
 			ResourceUpToDate: serviceBinding.LastOperation.Type != v1alpha1.LastOperationUpdate, // set to false when the last operation is update, hence the reconciler will retry update
 		}, nil
 	case v1alpha1.LastOperationSucceeded:
+		resetCreateAttempts(cr)
 		cr.SetConditions(xpv1.Available())
 
 		return managed.ExternalObservation{
@@ -287,4 +306,27 @@ func (c *external) HandleObservationState(serviceBinding *cfresource.ServiceCred
 
 	// If the last operation is unknown, error out
 	return managed.ExternalObservation{}, errors.New(errUnknownState)
+}
+
+func getCreateAttempts(cr *v1alpha1.ServiceCredentialBinding) int {
+	val := cr.GetAnnotations()[createAttemptsAnnotation]
+	if val == "" {
+		return 0
+	}
+	n, err := strconv.Atoi(val)
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+func incrementCreateAttempts(cr *v1alpha1.ServiceCredentialBinding) {
+	n := getCreateAttempts(cr)
+	meta.AddAnnotations(cr, map[string]string{
+		createAttemptsAnnotation: strconv.Itoa(n + 1),
+	})
+}
+
+func resetCreateAttempts(cr *v1alpha1.ServiceCredentialBinding) {
+	meta.RemoveAnnotations(cr, createAttemptsAnnotation)
 }

--- a/internal/controller/servicecredentialbinding/controller.go
+++ b/internal/controller/servicecredentialbinding/controller.go
@@ -293,10 +293,12 @@ func (c *external) HandleObservationState(serviceBinding *cfresource.ServiceCred
 			ResourceUpToDate: serviceBinding.LastOperation.Type != v1alpha1.LastOperationUpdate, // set to false when the last operation is update, hence the reconciler will retry update
 		}, nil
 	case v1alpha1.LastOperationSucceeded:
-		resetCreateAttempts(cr)
+		if getCreateAttempts(cr) > 0 {
+			resetCreateAttempts(cr)
 
-		if err := c.kube.Update(ctx, cr); err != nil {
-			return managed.ExternalObservation{}, fmt.Errorf("cannot persist create attempt reset: %w", err)
+			if err := c.kube.Update(ctx, cr); err != nil {
+				return managed.ExternalObservation{}, fmt.Errorf("cannot persist create attempt reset: %w", err)
+			}
 		}
 
 		cr.SetConditions(xpv1.Available())

--- a/internal/controller/servicecredentialbinding/controller_test.go
+++ b/internal/controller/servicecredentialbinding/controller_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"testing"
 	"time"
 
@@ -25,7 +26,7 @@ import (
 )
 
 var (
-	errBoom                   = errors.New("boom")
+	errCFClientError          = errors.New("boom")
 	errServiceInstanceMissing = errors.New(servicecredentialbinding.ErrServiceInstanceMissing)
 	errAppMissing             = errors.New(servicecredentialbinding.ErrAppMissing)
 	name                      = "my-service-credential-binding"
@@ -170,24 +171,24 @@ func TestObserve(t *testing.T) {
 				return m
 			},
 		},
-		"Boom!": {
+		"CFClientError": {
 			args: args{
 				mg: scb.DeepCopy(),
 			},
 			want: want{
 				mg:  serviceCredentialBinding("key", withExternalName(guid)),
 				obs: managed.ExternalObservation{},
-				err: fmt.Errorf(errGet, errBoom),
+				err: fmt.Errorf(errGet, errCFClientError),
 			},
 			service: func() *fake.MockServiceCredentialBinding {
 				m := &fake.MockServiceCredentialBinding{}
 				m.On("Get", mock.Anything, guid).Return(
 					fake.ServiceCredentialBindingNil,
-					errBoom,
+					errCFClientError,
 				)
 				m.On("Single").Return(
 					fake.ServiceCredentialBindingNil,
-					errBoom,
+					errCFClientError,
 				)
 				return m
 			},
@@ -296,6 +297,28 @@ func TestObserve(t *testing.T) {
 					nil,
 				)
 				return m
+			},
+		},
+		"CircuitBreakerTripped": {
+			args: args{
+				mg: serviceCredentialBinding("key",
+					withExternalName(guid),
+					withServiceInstanceID(serviceInstanceGUID),
+					withCreateAttempts(maxCreateAttempts),
+				),
+			},
+			want: want{
+				obs: managed.ExternalObservation{
+					ResourceExists:   true,
+					ResourceUpToDate: true,
+				},
+				err: nil,
+			},
+			service: func() *fake.MockServiceCredentialBinding {
+				return &fake.MockServiceCredentialBinding{}
+			},
+			keyRotator: func() *fake.MockKeyRotator {
+				return &fake.MockKeyRotator{}
 			},
 		}}
 
@@ -620,7 +643,7 @@ func TestHandleObservationState(t *testing.T) {
 			},
 			want: want{
 				obs: managed.ExternalObservation{
-					ResourceExists:   false, // Create failed, so resource doesn't exist
+					ResourceExists:   true, // circuit breaker handles retry gating
 					ResourceUpToDate: true,
 				},
 				err: nil,
@@ -1050,6 +1073,14 @@ func TestDelete(t *testing.T) {
 			if diff := cmp.Diff(tc.want.mg, tc.args.mg); diff != "" {
 				t.Errorf("Delete(...): -want, +got:\n%s", diff)
 			}
+		})
+	}
+}
+
+func withCreateAttempts(n int) modifier {
+	return func(r *v1alpha1.ServiceCredentialBinding) {
+		meta.AddAnnotations(r, map[string]string{
+			createAttemptsAnnotation: strconv.Itoa(n),
 		})
 	}
 }

--- a/internal/controller/servicecredentialbinding/controller_test.go
+++ b/internal/controller/servicecredentialbinding/controller_test.go
@@ -606,6 +606,7 @@ func TestHandleObservationState(t *testing.T) {
 	cases := map[string]struct {
 		args args
 		want want
+		kube k8s.Client
 	}{
 		"LastOperationInitial": {
 			args: args{
@@ -694,14 +695,35 @@ func TestHandleObservationState(t *testing.T) {
 				err: errors.New(errUnknownState),
 			},
 		},
+		"LastOperationSucceeded_KubeUpdateFails": {
+			args: args{
+				serviceBinding: scbCreate(v1alpha1.LastOperationSucceeded),
+				ctx:            ctx,
+				cr:             cr.DeepCopy(),
+			},
+			kube: &test.MockClient{
+				MockUpdate: test.NewMockUpdateFn(errCFClientError),
+			},
+			want: want{
+				obs: managed.ExternalObservation{},
+				err: fmt.Errorf("cannot persist create attempt reset: %w", errCFClientError),
+			},
+		},
 	}
 
 	for n, tc := range cases {
 		t.Run(n, func(t *testing.T) {
 			t.Logf("Testing: %s", t.Name())
+			kube := tc.kube
+			if kube == nil {
+				kube = &test.MockClient{
+					MockUpdate: test.NewMockUpdateFn(nil),
+				}
+			}
 
 			// Create external with mocked dependencies
 			c := &external{
+				kube:       kube,
 				scbClient:  &fake.MockServiceCredentialBinding{},
 				keyRotator: &fake.MockKeyRotator{},
 			}

--- a/internal/controller/servicecredentialbinding/controller_test.go
+++ b/internal/controller/servicecredentialbinding/controller_test.go
@@ -699,7 +699,11 @@ func TestHandleObservationState(t *testing.T) {
 			args: args{
 				serviceBinding: scbCreate(v1alpha1.LastOperationSucceeded),
 				ctx:            ctx,
-				cr:             cr.DeepCopy(),
+				cr: serviceCredentialBinding("key",
+					withExternalName(guid),
+					withServiceInstanceID(serviceInstanceGUID),
+					withCreateAttempts(3), // needs non-zero counter to trigger the update
+				),
 			},
 			kube: &test.MockClient{
 				MockUpdate: test.NewMockUpdateFn(errCFClientError),

--- a/internal/controller/servicecredentialbinding/controller_test.go
+++ b/internal/controller/servicecredentialbinding/controller_test.go
@@ -771,6 +771,7 @@ func TestCreate(t *testing.T) {
 					"key",
 					withExternalName(guid),
 					withServiceInstanceID(serviceInstanceGUID),
+					withCreateAttempts(1),
 				),
 				obs: managed.ExternalCreation{},
 				err: nil,
@@ -795,7 +796,7 @@ func TestCreate(t *testing.T) {
 				mg: serviceCredentialBinding("key"),
 			},
 			want: want{
-				mg:  serviceCredentialBinding("key"),
+				mg:  serviceCredentialBinding("key", withCreateAttempts(1)),
 				obs: managed.ExternalCreation{},
 				err: fmt.Errorf(errCreate, errServiceInstanceMissing),
 			},
@@ -822,7 +823,7 @@ func TestCreate(t *testing.T) {
 				mg: serviceCredentialBinding("app", withServiceInstanceID(serviceInstanceGUID)),
 			},
 			want: want{
-				mg: serviceCredentialBinding("app", withServiceInstanceID(serviceInstanceGUID)),
+				mg: serviceCredentialBinding("app", withServiceInstanceID(serviceInstanceGUID), withCreateAttempts(1)),
 
 				obs: managed.ExternalCreation{},
 				err: fmt.Errorf(errCreate, errAppMissing),
@@ -853,6 +854,7 @@ func TestCreate(t *testing.T) {
 				mg: serviceCredentialBinding(
 					"key",
 					withServiceInstanceID(serviceInstanceGUID),
+					withCreateAttempts(1),
 				),
 				obs: managed.ExternalCreation{},
 				err: fmt.Errorf(errCreate, errCFClientError),
@@ -883,7 +885,9 @@ func TestCreate(t *testing.T) {
 				mg: serviceCredentialBinding(
 					"key",
 					withServiceInstanceID(serviceInstanceGUID),
+					withCreateAttempts(1),
 				),
+
 				obs: managed.ExternalCreation{},
 				err: fmt.Errorf(errCreate, errCFClientError),
 			},

--- a/internal/controller/servicecredentialbinding/controller_test.go
+++ b/internal/controller/servicecredentialbinding/controller_test.go
@@ -430,13 +430,13 @@ func TestUpdate(t *testing.T) {
 			want: want{
 				mg:  serviceCredentialBinding("key", withServiceInstanceID(serviceInstanceGUID), withExternalName(guid)),
 				obs: managed.ExternalUpdate{},
-				err: fmt.Errorf(errUpdate, errBoom),
+				err: fmt.Errorf(errUpdate, errCFClientError),
 			},
 			service: func() *fake.MockServiceCredentialBinding {
 				m := &fake.MockServiceCredentialBinding{}
 				m.On("Update", mock.Anything, guid, mock.Anything).Return(
 					(*cfresource.ServiceCredentialBinding)(nil),
-					errBoom,
+					errCFClientError,
 				)
 				return m
 			},
@@ -478,7 +478,7 @@ func TestUpdate(t *testing.T) {
 			want: want{
 				mg:  mgWithRetiredKeys.DeepCopy(),
 				obs: managed.ExternalUpdate{},
-				err: fmt.Errorf(errDeleteExpiredKeys, errBoom),
+				err: fmt.Errorf(errDeleteExpiredKeys, errCFClientError),
 			},
 			service: func() *fake.MockServiceCredentialBinding {
 				m := &fake.MockServiceCredentialBinding{}
@@ -492,7 +492,7 @@ func TestUpdate(t *testing.T) {
 				m := &fake.MockKeyRotator{}
 				m.On("DeleteExpiredKeys", mock.Anything, mgWithRetiredKeys.DeepCopy()).Return(
 					[]*v1alpha1.SCBResource{},
-					errBoom,
+					errCFClientError,
 				)
 				return m
 			},
@@ -855,7 +855,7 @@ func TestCreate(t *testing.T) {
 					withServiceInstanceID(serviceInstanceGUID),
 				),
 				obs: managed.ExternalCreation{},
-				err: fmt.Errorf(errCreate, errBoom),
+				err: fmt.Errorf(errCreate, errCFClientError),
 			},
 			service: func() *fake.MockServiceCredentialBinding {
 				m := &fake.MockServiceCredentialBinding{}
@@ -870,7 +870,7 @@ func TestCreate(t *testing.T) {
 					scbKey(),
 					nil,
 				)
-				m.On("PollComplete", mock.Anything, mock.Anything, mock.Anything).Return(errBoom)
+				m.On("PollComplete", mock.Anything, mock.Anything, mock.Anything).Return(errCFClientError)
 
 				return m
 			},
@@ -885,14 +885,14 @@ func TestCreate(t *testing.T) {
 					withServiceInstanceID(serviceInstanceGUID),
 				),
 				obs: managed.ExternalCreation{},
-				err: fmt.Errorf(errCreate, errBoom),
+				err: fmt.Errorf(errCreate, errCFClientError),
 			},
 			service: func() *fake.MockServiceCredentialBinding {
 				m := &fake.MockServiceCredentialBinding{}
 				m.On("Create", mock.Anything, mock.Anything).Return(
 					guid,
 					scbKey(),
-					errBoom,
+					errCFClientError,
 				)
 				m.On("Single", mock.Anything, mock.Anything).Return(
 					scbKey(),
@@ -990,11 +990,11 @@ func TestDelete(t *testing.T) {
 			},
 			want: want{
 				mg:  mgWant.DeepCopy(),
-				err: fmt.Errorf(errDelete, errBoom),
+				err: fmt.Errorf(errDelete, errCFClientError),
 			},
 			service: func() *fake.MockServiceCredentialBinding {
 				m := &fake.MockServiceCredentialBinding{}
-				m.On("Delete", mock.Anything, guid).Return("", errBoom)
+				m.On("Delete", mock.Anything, guid).Return("", errCFClientError)
 				return m
 			},
 			keyRotator: func() *fake.MockKeyRotator {
@@ -1012,7 +1012,7 @@ func TestDelete(t *testing.T) {
 			},
 			want: want{
 				mg:  mgWant.DeepCopy(), // Should have Deleting condition set even if DeleteRetiredKeys fails
-				err: fmt.Errorf(errDeleteRetiredKeys, errBoom),
+				err: fmt.Errorf(errDeleteRetiredKeys, errCFClientError),
 			},
 			service: func() *fake.MockServiceCredentialBinding {
 				m := &fake.MockServiceCredentialBinding{}
@@ -1024,7 +1024,7 @@ func TestDelete(t *testing.T) {
 				// The object will have Deleting condition set when DeleteRetiredKeys is called
 				m.On("DeleteRetiredKeys", mock.Anything, mock.MatchedBy(func(cr *v1alpha1.ServiceCredentialBinding) bool {
 					return cr.GetCondition(xpv1.TypeReady).Reason == xpv1.ReasonDeleting
-				})).Return(errBoom)
+				})).Return(errCFClientError)
 				return m
 			},
 		},


### PR DESCRIPTION
## Problem
When a `ServiceCredentialBinding creation` fails (e.g. due to an invalid broker parameter or a feature not enabled in a landscape), the controller enters an infinite reconciliation loop, repeatedly attempting to create new bindings in CF. This causes the CF org to accumulate a large number of failed bindings, eventually making the org unresponsive and preventing deletion of the affected service instance.
The root cause was in `HandleObservationState`: when `LastOperation.State=failed` and `LastOperation.Type=create`, it returned `ResourceExists: false`, which signals crossplane-runtime to call `Create()` again immediately on the next reconcile cycle.
Fixes [Issue](https://github.tools.sap/openmcp/support/issues/586)

## Solution
Introduce a circuit breaker using a crossplane-provider-cloudfoundry/create-attempts annotation on the CR that tracks the number of creation attempts.

Related:
Ticket:  [Issue](https://github.tools.sap/openmcp/support/issues/586)
CF org impact: unresponsive org in JP31 landscape, v0.3.3