### PR TITLE
Implement custom teardown overwrite for import test

### DIFF
--- a/test/e2e/cloudfoundry_org_import_test.go
+++ b/test/e2e/cloudfoundry_org_import_test.go
@@ -3,11 +3,14 @@
 package e2e
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/SAP/crossplane-provider-cloudfoundry/apis/resources/v1alpha1"
+	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
 )
 
 var (
@@ -28,6 +31,28 @@ func TestOrgImportFlow(t *testing.T) {
 		WithDependentResourceDirectory[*v1alpha1.Organization]("./crs/org"),
 		WithWaitCreateTimeout[*v1alpha1.Organization](wait.WithTimeout(5*time.Minute)),
 		WithWaitDeletionTimeout[*v1alpha1.Organization](wait.WithTimeout(5*time.Minute)),
+		WithCustomTeardown(func(it *ImportTester[*v1alpha1.Organization], ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			resource := it.BaseResource.DeepCopyObject().(*v1alpha1.Organization)
+			MustGetResource(t, cfg, it.GetPrefixedName(), nil, resource)
+
+			// Switch to observe-only so teardown does not delete the shared external resource.
+			resource.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionObserve})
+			if err := cfg.Client().Resources().Update(ctx, resource); err != nil {
+				t.Fatalf("Failed to switch imported resource to observe-only before teardown: %v", err)
+			}
+
+			log("Deleting imported resource", resource, func() {
+				AwaitResourceDeletionOrFail(ctx, t, cfg, resource, it.WaitDeletionTimeout)
+			})
+
+			log("Deleting dependent resources", resource, func() {
+				if it.DependentResourceDirectory != "" {
+					DeleteResourcesIgnoreMissing(ctx, t, cfg, it.DependentResourceDirectory, it.WaitDeletionTimeout)
+				}
+			})
+
+			return ctx
+		}),
 	)
 
 	importFeature := importTester.BuildTestFeature("CF Org Import Flow").Feature()

--- a/test/e2e/import_utils_test.go
+++ b/test/e2e/import_utils_test.go
@@ -56,9 +56,13 @@ type ImportTester[T resource.Managed] struct {
 
 	// the timeout for waiting till resource get deleted (in setup and teardown)
 	WaitDeletionTimeout wait.Option
+
+	// optional custom teardown func that overrides default teardown func when set
+	CustomTeardown CustomTeardownFunc[T]
 }
 
 type ImportTesterOption[T resource.Managed] func(*ImportTester[T])
+type CustomTeardownFunc[T resource.Managed] func(*ImportTester[T], context.Context, *testing.T, *envconf.Config) context.Context
 
 func WithWaitDependentResourceTimeout[T resource.Managed](timeout wait.Option) ImportTesterOption[T] {
 	return func(it *ImportTester[T]) {
@@ -81,6 +85,12 @@ func WithWaitDeletionTimeout[T resource.Managed](timeout wait.Option) ImportTest
 func WithDependentResourceDirectory[T resource.Managed](path string) ImportTesterOption[T] {
 	return func(it *ImportTester[T]) {
 		it.DependentResourceDirectory = path
+	}
+}
+
+func WithCustomTeardown[T resource.Managed](teardown CustomTeardownFunc[T]) ImportTesterOption[T] {
+	return func(it *ImportTester[T]) {
+		it.CustomTeardown = teardown
 	}
 }
 
@@ -109,7 +119,7 @@ func (it *ImportTester[T]) GetPrefixedName() string {
 }
 
 func (it *ImportTester[T]) BuildTestFeature(name string) *features.FeatureBuilder {
-	return features.New(name).
+	tf := features.New(name).
 		Setup(
 			func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 				r, _ := res.New(cfg.Client().RESTConfig())
@@ -172,7 +182,16 @@ func (it *ImportTester[T]) BuildTestFeature(name string) *features.FeatureBuilde
 			})
 			return ctx
 		},
-	).Teardown(
+	)
+
+	if it.CustomTeardown != nil {
+		tf.Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			return it.CustomTeardown(it, ctx, t, cfg)
+		})
+		return tf
+	}
+
+	tf.Teardown(
 		func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			resource := it.BaseResource.DeepCopyObject().(T)
 			MustGetResource(t, cfg, it.GetPrefixedName(), nil, resource)
@@ -189,6 +208,7 @@ func (it *ImportTester[T]) BuildTestFeature(name string) *features.FeatureBuilde
 			return ctx
 		},
 	)
+	return tf
 }
 
 // log is a helper function to log the start and end of an operation on a managed resource with name and external name.

--- a/test/e2e/import_utils_test.go
+++ b/test/e2e/import_utils_test.go
@@ -177,12 +177,6 @@ func (it *ImportTester[T]) BuildTestFeature(name string) *features.FeatureBuilde
 			resource := it.BaseResource.DeepCopyObject().(T)
 			MustGetResource(t, cfg, it.GetPrefixedName(), nil, resource)
 
-			// Switch to observe-only so teardown does not delete the shared external resource.
-			resource.SetManagementPolicies(xpv1.ManagementPolicies{xpv1.ManagementActionObserve})
-			if err := cfg.Client().Resources().Update(ctx, resource); err != nil {
-				t.Fatalf("Failed to switch imported resource to observe-only before teardown: %v", err)
-			}
-
 			log("Deleting imported resource", resource, func() {
 				AwaitResourceDeletionOrFail(ctx, t, cfg, resource, it.WaitDeletionTimeout)
 			})


### PR DESCRIPTION
Implement custom teardown overwrite for import tests so resources like org can be tested