### PR TITLE
[281#2] refactor(srb): migrate SRB controller to shared metadata package

### DIFF
--- a/internal/clients/metadata/metadata.go
+++ b/internal/clients/metadata/metadata.go
@@ -26,7 +26,10 @@ import (
 // not yet exist). On Update calls, include nil values for keys you want to
 // explicitly remove from the CF resource.
 func BuildMetadata(mg resource.Managed, userLabels, userAnnotations map[string]*string) *cfresource.Metadata {
-	tags := resource.GetExternalTags(mg)
+	var tags map[string]string
+	if mg != nil {
+		tags = resource.GetExternalTags(mg)
+	}
 	m := cfresource.NewMetadata()
 
 	// Set default labels from Crossplane (map[string]string -> map[string]*string)

--- a/internal/clients/metadata/metadata_test.go
+++ b/internal/clients/metadata/metadata_test.go
@@ -181,6 +181,20 @@ func TestBuildMetadata(t *testing.T) {
 			t.Errorf("expected nil (deletion marker) for crossplane-name, got %v", v)
 		}
 	})
+
+	t.Run("nil managed resource - no default labels", func(t *testing.T) {
+		m := BuildMetadata(nil, nil, nil)
+
+		if m == nil {
+			t.Fatal("expected non-nil metadata")
+		}
+		if len(m.Labels) != 0 {
+			t.Fatalf("expected 0 labels with nil mg, got %d", len(m.Labels))
+		}
+		if len(m.Annotations) != 0 {
+			t.Fatalf("expected 0 annotations with nil mg, got %d", len(m.Annotations))
+		}
+	})
 }
 
 func TestMetadataMapEqual(t *testing.T) {

--- a/internal/clients/serviceroutebinding/serviceroutebinding.go
+++ b/internal/clients/serviceroutebinding/serviceroutebinding.go
@@ -7,10 +7,12 @@ import (
 
 	"github.com/cloudfoundry/go-cfclient/v3/client"
 	"github.com/cloudfoundry/go-cfclient/v3/resource"
+	xpresource "github.com/crossplane/crossplane-runtime/pkg/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/SAP/crossplane-provider-cloudfoundry/apis/resources/v1alpha1"
 	"github.com/SAP/crossplane-provider-cloudfoundry/internal/clients/job"
+	"github.com/SAP/crossplane-provider-cloudfoundry/internal/clients/metadata"
 )
 
 type serviceRouteBinding interface {
@@ -40,8 +42,8 @@ func GetByID(ctx context.Context, srbClient ServiceRouteBinding, guid string) (*
 	return srbClient.Get(ctx, guid)
 }
 
-func Create(ctx context.Context, srbClient ServiceRouteBinding, forProvider v1alpha1.ServiceRouteBindingParameters, parametersFromSecret runtime.RawExtension) (*resource.ServiceRouteBinding, error) {
-	opt := newCreateOption(forProvider, parametersFromSecret)
+func Create(ctx context.Context, srbClient ServiceRouteBinding, mg xpresource.Managed, forProvider v1alpha1.ServiceRouteBindingParameters, parametersFromSecret runtime.RawExtension) (*resource.ServiceRouteBinding, error) {
+	opt := newCreateOption(mg, forProvider, parametersFromSecret)
 
 	jobGUID, binding, err := srbClient.Create(ctx, opt)
 	if err != nil {
@@ -56,7 +58,7 @@ func Create(ctx context.Context, srbClient ServiceRouteBinding, forProvider v1al
 	return srbClient.Single(ctx, createToListOptions(opt))
 }
 
-func newCreateOption(forProvider v1alpha1.ServiceRouteBindingParameters, parametersFromSecret runtime.RawExtension) *resource.ServiceRouteBindingCreate {
+func newCreateOption(mg xpresource.Managed, forProvider v1alpha1.ServiceRouteBindingParameters, parametersFromSecret runtime.RawExtension) *resource.ServiceRouteBindingCreate {
 	creationPayload := resource.NewServiceRouteBindingCreate(forProvider.Route, forProvider.ServiceInstance)
 
 	if forProvider.Parameters.Raw != nil {
@@ -64,6 +66,7 @@ func newCreateOption(forProvider v1alpha1.ServiceRouteBindingParameters, paramet
 	} else if parametersFromSecret.Raw != nil {
 		creationPayload.Parameters = (*json.RawMessage)(&parametersFromSecret.Raw)
 	}
+	creationPayload.Metadata = metadata.BuildMetadata(mg, forProvider.Labels, forProvider.Annotations)
 	return creationPayload
 }
 

--- a/internal/clients/serviceroutebinding/serviceroutebinding_test.go
+++ b/internal/clients/serviceroutebinding/serviceroutebinding_test.go
@@ -127,7 +127,7 @@ func TestNewCreateOption(t *testing.T) {
 
 	for n, tc := range cases {
 		t.Run(n, func(t *testing.T) {
-			opt := newCreateOption(tc.args.forProvider, tc.args.parametersFromSecret)
+			opt := newCreateOption(nil, tc.args.forProvider, tc.args.parametersFromSecret)
 
 			if tc.want.opt != nil && opt != nil {
 				if opt.Relationships.Route.Data.GUID != tc.want.opt.Relationships.Route.Data.GUID {
@@ -874,7 +874,7 @@ func TestCreate(t *testing.T) {
 
 	for n, tc := range cases {
 		t.Run(n, func(t *testing.T) {
-			binding, err := Create(tc.args.ctx, tc.args.srbClient, tc.args.forProvider, tc.args.parametersFromSecret)
+			binding, err := Create(tc.args.ctx, tc.args.srbClient, nil, tc.args.forProvider, tc.args.parametersFromSecret)
 
 			if tc.want.err != nil {
 				if err == nil {

--- a/internal/controller/serviceroutebinding/controller.go
+++ b/internal/controller/serviceroutebinding/controller.go
@@ -24,6 +24,7 @@ import (
 	apisv1beta1 "github.com/SAP/crossplane-provider-cloudfoundry/apis/v1beta1"
 	"github.com/SAP/crossplane-provider-cloudfoundry/internal/clients"
 	"github.com/SAP/crossplane-provider-cloudfoundry/internal/clients/job"
+	"github.com/SAP/crossplane-provider-cloudfoundry/internal/clients/metadata"
 	srb "github.com/SAP/crossplane-provider-cloudfoundry/internal/clients/serviceroutebinding"
 	"github.com/SAP/crossplane-provider-cloudfoundry/internal/features"
 )
@@ -198,7 +199,7 @@ func (e *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 		parameterFromSecret = *parameters
 	}
 
-	binding, err := srb.Create(ctx, e.srbClient, cr.Spec.ForProvider, parameterFromSecret)
+	binding, err := srb.Create(ctx, e.srbClient, cr, cr.Spec.ForProvider, parameterFromSecret)
 	if err != nil {
 		return managed.ExternalCreation{}, fmt.Errorf(errCreate, err)
 	} else if binding == nil {
@@ -306,58 +307,15 @@ func handleObservationState(binding *cfresource.ServiceRouteBinding, cr *v1alpha
 		cr.SetConditions(xpv1.Available(), xpv1.ReconcileSuccess())
 
 		// Check if metadata (labels/annotations) needs to be updated
-		upToDate := isMetadataUpToDate(cr.Spec.ForProvider, binding)
+		var actualLabels, actualAnnotations map[string]*string
+		if binding.Metadata != nil {
+			actualLabels = binding.Metadata.Labels
+			actualAnnotations = binding.Metadata.Annotations
+		}
+		upToDate := metadata.IsMetadataUpToDate(cr.Spec.ForProvider.Labels, cr.Spec.ForProvider.Annotations, actualLabels, actualAnnotations)
 
 		return managed.ExternalObservation{ResourceExists: true, ResourceUpToDate: upToDate}, nil
 	}
 
 	return managed.ExternalObservation{}, errors.New(errUnknownState)
-}
-
-// isMetadataUpToDate checks if labels and annotations match between desired state (spec) and actual state (CF).
-// Returns true if metadata is up-to-date, false if an update is needed.
-func isMetadataUpToDate(spec v1alpha1.ServiceRouteBindingParameters, binding *cfresource.ServiceRouteBinding) bool {
-	// If no metadata in CF resource, check if spec wants to set any
-	if binding.Metadata == nil {
-		return spec.Labels == nil && spec.Annotations == nil
-	}
-
-	if !metadataMapEqual(spec.Labels, binding.Metadata.Labels) {
-		return false
-	}
-
-	if !metadataMapEqual(spec.Annotations, binding.Metadata.Annotations) {
-		return false
-	}
-
-	return true
-}
-
-// metadataMapEqual compares two metadata maps (labels or annotations).
-func metadataMapEqual(desired, actual map[string]*string) bool {
-	// check if both are nil/empty
-	if len(desired) == 0 && len(actual) == 0 {
-		return true
-	}
-
-	if len(desired) != len(actual) {
-		return false
-	}
-
-	// Compare each key-value pair
-	for key, desiredVal := range desired {
-		actualVal, exists := actual[key]
-		if !exists {
-			return false
-		}
-
-		if (desiredVal == nil) != (actualVal == nil) {
-			return false
-		}
-		if desiredVal != nil && actualVal != nil && *desiredVal != *actualVal {
-			return false
-		}
-	}
-
-	return true
 }

--- a/internal/controller/serviceroutebinding/controller_test.go
+++ b/internal/controller/serviceroutebinding/controller_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/SAP/crossplane-provider-cloudfoundry/apis/resources/v1alpha1"
 	"github.com/SAP/crossplane-provider-cloudfoundry/internal/clients"
 	"github.com/SAP/crossplane-provider-cloudfoundry/internal/clients/fake"
+	"github.com/SAP/crossplane-provider-cloudfoundry/internal/clients/metadata"
 )
 
 var (
@@ -1095,7 +1096,7 @@ func TestIsMetadataUpToDate(t *testing.T) {
 					},
 				},
 			},
-			expected: false,
+			expected: true,
 		},
 		"SpecWithoutMetadataBindingHasLabels": {
 			spec: v1alpha1.ServiceRouteBindingParameters{},
@@ -1106,7 +1107,7 @@ func TestIsMetadataUpToDate(t *testing.T) {
 					},
 				},
 			},
-			expected: false,
+			expected: true,
 		},
 		"SpecHasLabelsBindingHasNoMetadata": {
 			spec: v1alpha1.ServiceRouteBindingParameters{
@@ -1125,9 +1126,14 @@ func TestIsMetadataUpToDate(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			result := isMetadataUpToDate(tc.spec, tc.binding)
+			var actualLabels, actualAnnotations map[string]*string
+			if tc.binding.Metadata != nil {
+				actualLabels = tc.binding.Metadata.Labels
+				actualAnnotations = tc.binding.Metadata.Annotations
+			}
+			result := metadata.IsMetadataUpToDate(tc.spec.Labels, tc.spec.Annotations, actualLabels, actualAnnotations)
 			if diff := cmp.Diff(tc.expected, result); diff != "" {
-				t.Errorf("isMetadataUpToDate(...): -want, +got:\n%s", diff)
+				t.Errorf("metadata.IsMetadataUpToDate(...): -want, +got:\n%s", diff)
 			}
 		})
 	}
@@ -1235,9 +1241,9 @@ func TestMetadataMapEqual(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			result := metadataMapEqual(tc.desired, tc.actual)
+			result := metadata.MetadataMapEqual(tc.desired, tc.actual)
 			if diff := cmp.Diff(tc.expected, result); diff != "" {
-				t.Errorf("metadataMapEqual(...): -want, +got:\n%s", diff)
+				t.Errorf("metadata.MetadataMapEqual(...): -want, +got:\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
## What
- Remove ~45 lines of duplicated `isMetadataUpToDate`/`metadataMapEqual` from SRB controller
- Replace with shared `metadata.IsMetadataUpToDate` and `metadata.MetadataMapContains`
- Adopts correct merge-patch semantics (subset check via MetadataMapContains) instead of exact equality
- Denest nil-mg test case in metadata_test.go

## Test Changes
- `ExtraLabelInActual`: false → true (desired is subset of actual)
- `SpecWithoutMetadataBindingHasLabels`: false → true (empty desired is subset of anything)

## Part of
Split from #281 — PR 2 of 6. Depends on [281#1].

**Merge order:** [281#1] → [281#2] → [281#3] → [281#4] → [281#5] → [281#6]