### PR TITLE
[281#3] feat: wire Crossplane default labels and user metadata into all CF resources

### DIFF
--- a/apis/resources/v1alpha1/space_types.go
+++ b/apis/resources/v1alpha1/space_types.go
@@ -46,6 +46,7 @@ type SpaceObservation struct {
 type SpaceParameters struct {
 
 	// (Boolean) Allows SSH to application containers via the CF CLI.
+	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=false
 	AllowSSH bool `json:"allowSsh,omitempty" tf:"allow_ssh,omitempty"`
 

--- a/internal/clients/app/app.go
+++ b/internal/clients/app/app.go
@@ -9,11 +9,13 @@ import (
 	"github.com/cloudfoundry/go-cfclient/v3/client"
 	"github.com/cloudfoundry/go-cfclient/v3/operation"
 	"github.com/cloudfoundry/go-cfclient/v3/resource"
+	xpresource "github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/google/uuid"
 	"k8s.io/utils/ptr"
 
 	"github.com/SAP/crossplane-provider-cloudfoundry/apis/resources/v1alpha1"
 	"github.com/SAP/crossplane-provider-cloudfoundry/internal/clients/job"
+	"github.com/SAP/crossplane-provider-cloudfoundry/internal/clients/metadata"
 	"github.com/SAP/crossplane-provider-cloudfoundry/internal/clients/servicecredentialbinding"
 )
 
@@ -74,13 +76,13 @@ func (c *Client) GetByIDOrSpec(ctx context.Context, guid string, spec v1alpha1.A
 }
 
 // CreateAndPush creates and pushes an app to the Cloud Foundry.
-func (c *Client) CreateAndPush(ctx context.Context, spec v1alpha1.AppParameters, dockerCredentials *DockerCredentials) (*resource.App, error) {
+func (c *Client) CreateAndPush(ctx context.Context, mg xpresource.Managed, spec v1alpha1.AppParameters, dockerCredentials *DockerCredentials) (*resource.App, error) {
 	manifest, err := newManifestFromSpec(spec, dockerCredentials)
 	if err != nil {
 		return nil, err
 	}
 
-	application, err := c.AppClient.Create(ctx, newCreateOption(spec))
+	application, err := c.AppClient.Create(ctx, newCreateOption(mg, spec))
 	if err != nil {
 		return nil, err
 	}
@@ -88,8 +90,8 @@ func (c *Client) CreateAndPush(ctx context.Context, spec v1alpha1.AppParameters,
 }
 
 // Update updates an app in the Cloud Foundry.
-func (c *Client) Update(ctx context.Context, guid string, spec v1alpha1.AppParameters) (*resource.App, error) {
-	application, err := c.AppClient.Update(ctx, guid, newUpdateOption(spec))
+func (c *Client) Update(ctx context.Context, guid string, mg xpresource.Managed, spec v1alpha1.AppParameters) (*resource.App, error) {
+	application, err := c.AppClient.Update(ctx, guid, newUpdateOption(mg, spec))
 	if err != nil {
 		return nil, err
 	}
@@ -97,13 +99,13 @@ func (c *Client) Update(ctx context.Context, guid string, spec v1alpha1.AppParam
 }
 
 // UpdateAndPush updates and pushes an app to the Cloud Foundry.
-func (c *Client) UpdateAndPush(ctx context.Context, guid string, spec v1alpha1.AppParameters, dockerCredentials *DockerCredentials) (*resource.App, error) {
+func (c *Client) UpdateAndPush(ctx context.Context, guid string, mg xpresource.Managed, spec v1alpha1.AppParameters, dockerCredentials *DockerCredentials) (*resource.App, error) {
 	manifest, err := newManifestFromSpec(spec, dockerCredentials)
 	if err != nil {
 		return nil, err
 	}
 
-	application, err := c.AppClient.Update(ctx, guid, newUpdateOption(spec))
+	application, err := c.AppClient.Update(ctx, guid, newUpdateOption(mg, spec))
 	if err != nil {
 		return nil, err
 	}
@@ -140,6 +142,11 @@ func GenerateObservation(res *resource.App) v1alpha1.AppObservation {
 	obs.State = res.State
 	obs.CreatedAt = ptr.To(res.CreatedAt.Format(time.RFC3339))
 	obs.UpdatedAt = ptr.To(res.UpdatedAt.Format(time.RFC3339))
+
+	if res.Metadata != nil {
+		obs.Labels = res.Metadata.Labels
+		obs.Annotations = res.Metadata.Annotations
+	}
 
 	return obs
 }
@@ -212,12 +219,14 @@ func DetectChanges(spec v1alpha1.AppParameters, status v1alpha1.AppObservation) 
 	return changes, nil
 }
 
-func IsUpToDate(spec v1alpha1.AppParameters, status v1alpha1.AppObservation) (bool, error) {
+func IsUpToDate(mg xpresource.Managed, spec v1alpha1.AppParameters, status v1alpha1.AppObservation) (bool, error) {
 	changes, err := DetectChanges(spec, status)
 	if err != nil {
 		return false, err
 	}
-	return !changes.HasChanges(), nil
+	desired := metadata.BuildMetadata(mg, spec.Labels, spec.Annotations)
+	metadataUpToDate := metadata.IsMetadataUpToDate(desired.Labels, desired.Annotations, status.Labels, status.Annotations)
+	return !changes.HasChanges() && metadataUpToDate, nil
 }
 
 // DiffServiceBindings checks whether current state is up-to-date compared to the given
@@ -263,7 +272,7 @@ func newListOption(spec v1alpha1.AppParameters) *client.AppListOptions {
 }
 
 // newCreateOption maps spec to AppCreate option
-func newCreateOption(spec v1alpha1.AppParameters) *resource.AppCreate {
+func newCreateOption(mg xpresource.Managed, spec v1alpha1.AppParameters) *resource.AppCreate {
 	name := spec.Name
 	space := ptr.Deref(spec.Space, "")
 	appCreate := resource.NewAppCreate(name, space)
@@ -283,11 +292,12 @@ func newCreateOption(spec v1alpha1.AppParameters) *resource.AppCreate {
 	default:
 		appCreate.Lifecycle = nil
 	}
+	appCreate.Metadata = metadata.BuildMetadata(mg, spec.Labels, spec.Annotations)
 	return appCreate
 }
 
 // newUpdateOption map spec to AppCreate option
-func newUpdateOption(spec v1alpha1.AppParameters) *resource.AppUpdate {
+func newUpdateOption(mg xpresource.Managed, spec v1alpha1.AppParameters) *resource.AppUpdate {
 	var lifecycle *resource.Lifecycle
 	switch spec.Lifecycle {
 	case "buildpack":
@@ -309,7 +319,7 @@ func newUpdateOption(spec v1alpha1.AppParameters) *resource.AppUpdate {
 	return &resource.AppUpdate{
 		Name:      spec.Name,
 		Lifecycle: lifecycle,
-		Metadata:  &resource.Metadata{},
+		Metadata:  metadata.BuildMetadata(mg, spec.Labels, spec.Annotations),
 	}
 }
 

--- a/internal/clients/app/app_test.go
+++ b/internal/clients/app/app_test.go
@@ -3,6 +3,8 @@ package app
 import (
 	"testing"
 
+	"k8s.io/utils/ptr"
+
 	"github.com/SAP/crossplane-provider-cloudfoundry/apis/resources/v1alpha1"
 )
 
@@ -179,7 +181,99 @@ func TestIsUpToDate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := IsUpToDate(tt.spec, tt.status)
+			result, err := IsUpToDate(nil, tt.spec, tt.status)
+			if err != nil {
+				t.Fatalf("IsUpToDate() error = %v", err)
+			}
+			if result != tt.expected {
+				t.Errorf("IsUpToDate() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsUpToDate_Metadata(t *testing.T) {
+	tests := []struct {
+		name     string
+		spec     v1alpha1.AppParameters
+		status   v1alpha1.AppObservation
+		expected bool
+	}{
+		{
+			name: "Label drift - spec has labels but observation does not",
+			spec: v1alpha1.AppParameters{
+				Name:      "test-app",
+				Lifecycle: "docker",
+				Docker:    &v1alpha1.DockerConfiguration{Image: "nginx:latest"},
+				ResourceMetadata: v1alpha1.ResourceMetadata{
+					Labels: map[string]*string{"env": ptr.To("prod")},
+				},
+			},
+			status: v1alpha1.AppObservation{
+				Name:        "test-app",
+				AppManifest: "applications:\n- name: test-app\n  docker:\n    image: nginx:latest",
+			},
+			expected: false,
+		},
+		{
+			name: "Labels match",
+			spec: v1alpha1.AppParameters{
+				Name:      "test-app",
+				Lifecycle: "docker",
+				Docker:    &v1alpha1.DockerConfiguration{Image: "nginx:latest"},
+				ResourceMetadata: v1alpha1.ResourceMetadata{
+					Labels: map[string]*string{"env": ptr.To("prod")},
+				},
+			},
+			status: v1alpha1.AppObservation{
+				Name:        "test-app",
+				AppManifest: "applications:\n- name: test-app\n  docker:\n    image: nginx:latest",
+				ResourceMetadata: v1alpha1.ResourceMetadata{
+					Labels: map[string]*string{"env": ptr.To("prod")},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "Annotation drift - spec has annotations but observation does not",
+			spec: v1alpha1.AppParameters{
+				Name:      "test-app",
+				Lifecycle: "docker",
+				Docker:    &v1alpha1.DockerConfiguration{Image: "nginx:latest"},
+				ResourceMetadata: v1alpha1.ResourceMetadata{
+					Annotations: map[string]*string{"note": ptr.To("value")},
+				},
+			},
+			status: v1alpha1.AppObservation{
+				Name:        "test-app",
+				AppManifest: "applications:\n- name: test-app\n  docker:\n    image: nginx:latest",
+			},
+			expected: false,
+		},
+		{
+			name: "Annotations match",
+			spec: v1alpha1.AppParameters{
+				Name:      "test-app",
+				Lifecycle: "docker",
+				Docker:    &v1alpha1.DockerConfiguration{Image: "nginx:latest"},
+				ResourceMetadata: v1alpha1.ResourceMetadata{
+					Annotations: map[string]*string{"note": ptr.To("value")},
+				},
+			},
+			status: v1alpha1.AppObservation{
+				Name:        "test-app",
+				AppManifest: "applications:\n- name: test-app\n  docker:\n    image: nginx:latest",
+				ResourceMetadata: v1alpha1.ResourceMetadata{
+					Annotations: map[string]*string{"note": ptr.To("value")},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := IsUpToDate(nil, tt.spec, tt.status)
 			if err != nil {
 				t.Fatalf("IsUpToDate() error = %v", err)
 			}

--- a/internal/clients/domain/domain.go
+++ b/internal/clients/domain/domain.go
@@ -6,10 +6,12 @@ import (
 
 	"github.com/cloudfoundry/go-cfclient/v3/client"
 	"github.com/cloudfoundry/go-cfclient/v3/resource"
+	xpresource "github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/google/uuid"
 	"k8s.io/utils/ptr"
 
 	"github.com/SAP/crossplane-provider-cloudfoundry/apis/resources/v1alpha1"
+	"github.com/SAP/crossplane-provider-cloudfoundry/internal/clients/metadata"
 )
 
 // Client is the interface that defines the methods that a Domain client should implement.
@@ -42,8 +44,7 @@ func GetByIDOrName(ctx context.Context, c Client, id, name string) (*resource.Do
 }
 
 // GenerateCreate generates the DomainCreate from an *DomainParameters.
-func GenerateCreate(spec v1alpha1.DomainParameters) *resource.DomainCreate {
-	// if external-name is not set, search by Name and Space
+func GenerateCreate(mg xpresource.Managed, spec v1alpha1.DomainParameters) *resource.DomainCreate {
 	create := &resource.DomainCreate{}
 	create.Name = spec.Name
 
@@ -67,7 +68,7 @@ func GenerateCreate(spec v1alpha1.DomainParameters) *resource.DomainCreate {
 		create.Relationships.SharedOrganizations = resource.NewToManyRelationships(sharedOrgs)
 	}
 
-	// TODO: ADD labels and annotations
+	create.Metadata = metadata.BuildMetadata(mg, spec.Labels, spec.Annotations)
 	return create
 }
 
@@ -90,17 +91,17 @@ func GenerateObservation(o *resource.Domain) v1alpha1.DomainObservation {
 	}
 
 	if o.Metadata != nil {
-		obs.Annotations = o.Metadata.Annotations
 		obs.Labels = o.Metadata.Labels
+		obs.Annotations = o.Metadata.Annotations
 	}
 
 	return obs
 }
 
-// GenerateUpdate generates the Domain from an *DomainParameters. There is not really an option to update besides labels and annotations
-func GenerateUpdate(spec v1alpha1.DomainParameters) *resource.DomainUpdate {
+// GenerateUpdate generates the DomainUpdate from an *DomainParameters. There is not really an option to update besides labels and annotations
+func GenerateUpdate(mg xpresource.Managed, spec v1alpha1.DomainParameters) *resource.DomainUpdate {
 	return &resource.DomainUpdate{
-		Metadata: &resource.Metadata{Labels: spec.Labels, Annotations: spec.Annotations},
+		Metadata: metadata.BuildMetadata(mg, spec.Labels, spec.Annotations),
 	}
 }
 
@@ -108,37 +109,17 @@ func GenerateUpdate(spec v1alpha1.DomainParameters) *resource.DomainUpdate {
 // set of parameters.
 //
 //nolint:gocyclo
-func IsUpToDate(spec v1alpha1.DomainParameters, observed *resource.Domain) bool {
-	// domain update does not support rename and change of many attributes, and can only update labels and annotations. we can safely return true for now
-
-	// if spec.Name != observed.Name {
-	// 	return false
-	// }
-
-	// if spec.Internal != nil && *spec.Internal != observed.Internal {
-	// 	return false
-	// }
-
-	// if spec.RouterGroup != nil && (observed.RouterGroup == nil || *spec.RouterGroup != observed.RouterGroup.GUID) {
-	// 	return false
-	// }
-
-	// // Some domains are not organization-scoped, it returns Relationships.Organization.Data nil. Since update of org is support, we can omit this checks
-	// // if spec.Org != nil && (observed.Relationships.Organization == nil || *spec.Org != observed.Relationships.Organization.Data.GUID) {
-	// //		return false
-	// //	}
-
-	// if observed.Relationships.SharedOrganizations != nil && len(spec.SharedOrgs) != len(observed.Relationships.SharedOrganizations.Data) {
-	// 	return false
-	// }
-
-	// for i, org := range spec.SharedOrgs {
-	// 	if *org != observed.Relationships.SharedOrganizations.Data[i].GUID {
-	// 		return false
-	// 	}
-	// }
-
-	return true
+func IsUpToDate(mg xpresource.Managed, spec v1alpha1.DomainParameters, observed *resource.Domain) bool {
+	if observed == nil {
+		return false
+	}
+	desired := metadata.BuildMetadata(mg, spec.Labels, spec.Annotations)
+	var observedLabels, observedAnnotations map[string]*string
+	if observed.Metadata != nil {
+		observedLabels = observed.Metadata.Labels
+		observedAnnotations = observed.Metadata.Annotations
+	}
+	return metadata.IsMetadataUpToDate(desired.Labels, desired.Annotations, observedLabels, observedAnnotations)
 }
 
 // convertToStringPtrSlice converts a slice of resource.Relationship to a slice of string pointers.

--- a/internal/clients/fake/app.go
+++ b/internal/clients/fake/app.go
@@ -103,3 +103,18 @@ func (a *App) SetGUID(guid string) *App {
 	a.GUID = guid
 	return a
 }
+
+func (s *App) SetLabels(labels map[string]*string) *App {
+	if s.Metadata == nil {
+		s.Metadata = &resource.Metadata{}
+	}
+	s.Metadata.Labels = labels
+	return s
+}
+func (s *App) SetAnnotations(annotations map[string]*string) *App {
+	if s.Metadata == nil {
+		s.Metadata = &resource.Metadata{}
+	}
+	s.Metadata.Annotations = annotations
+	return s
+}

--- a/internal/clients/fake/domain.go
+++ b/internal/clients/fake/domain.go
@@ -70,3 +70,18 @@ func (s *Domain) SetGUID(guid string) *Domain {
 	s.GUID = guid
 	return s
 }
+
+func (s *Domain) SetLabels(labels map[string]*string) *Domain {
+	if s.Metadata == nil {
+		s.Metadata = &resource.Metadata{}
+	}
+	s.Metadata.Labels = labels
+	return s
+}
+func (s *Domain) SetAnnotations(annotations map[string]*string) *Domain {
+	if s.Metadata == nil {
+		s.Metadata = &resource.Metadata{}
+	}
+	s.Metadata.Annotations = annotations
+	return s
+}

--- a/internal/clients/fake/org.go
+++ b/internal/clients/fake/org.go
@@ -64,3 +64,18 @@ func (s *Organization) SetGUID(guid string) *Organization {
 	s.GUID = guid
 	return s
 }
+
+func (s *Organization) SetLabels(labels map[string]*string) *Organization {
+	if s.Metadata == nil {
+		s.Metadata = &resource.Metadata{}
+	}
+	s.Metadata.Labels = labels
+	return s
+}
+func (s *Organization) SetAnnotations(annotations map[string]*string) *Organization {
+	if s.Metadata == nil {
+		s.Metadata = &resource.Metadata{}
+	}
+	s.Metadata.Annotations = annotations
+	return s
+}

--- a/internal/clients/fake/route.go
+++ b/internal/clients/fake/route.go
@@ -43,7 +43,7 @@ func (m *MockRoute) Delete(ctx context.Context, guid string) (string, error) {
 	return args.Get(0).(string), args.Error(1)
 }
 
-// Route is a nil Route
+// RouteNil is a nil Route
 var (
 	RouteNil *resource.Route
 )
@@ -56,5 +56,29 @@ func FakeRoute(guid, url string) *resource.Route {
 		},
 		URL: url,
 	}
+	return r
+}
+
+type Route struct {
+	resource.Route
+}
+
+func NewRoute() *Route                      { return &Route{} }
+func (r *Route) SetHost(host string) *Route { r.Host = host; return r }
+func (r *Route) SetGUID(guid string) *Route { r.GUID = guid; return r }
+
+func (r *Route) SetLabels(labels map[string]*string) *Route {
+	if r.Metadata == nil {
+		r.Metadata = &resource.Metadata{}
+	}
+	r.Metadata.Labels = labels
+	return r
+}
+
+func (r *Route) SetAnnotations(annotations map[string]*string) *Route {
+	if r.Metadata == nil {
+		r.Metadata = &resource.Metadata{}
+	}
+	r.Metadata.Annotations = annotations
 	return r
 }

--- a/internal/clients/fake/servicecredentialbinding.go
+++ b/internal/clients/fake/servicecredentialbinding.go
@@ -116,3 +116,18 @@ func (s *ServiceCredentialBinding) SetLastOperation(op, state string) *ServiceCr
 	}
 	return s
 }
+
+func (s *ServiceCredentialBinding) SetLabels(labels map[string]*string) *ServiceCredentialBinding {
+	if s.Metadata == nil {
+		s.Metadata = &resource.Metadata{}
+	}
+	s.Metadata.Labels = labels
+	return s
+}
+func (s *ServiceCredentialBinding) SetAnnotations(annotations map[string]*string) *ServiceCredentialBinding {
+	if s.Metadata == nil {
+		s.Metadata = &resource.Metadata{}
+	}
+	s.Metadata.Annotations = annotations
+	return s
+}

--- a/internal/clients/fake/serviceinstance.go
+++ b/internal/clients/fake/serviceinstance.go
@@ -154,3 +154,18 @@ func (s *ServiceInstance) SetLastOperation(op, state string) *ServiceInstance {
 	}
 	return s
 }
+
+func (s *ServiceInstance) SetLabels(labels map[string]*string) *ServiceInstance {
+	if s.Metadata == nil {
+		s.Metadata = &resource.Metadata{}
+	}
+	s.Metadata.Labels = labels
+	return s
+}
+func (s *ServiceInstance) SetAnnotations(annotations map[string]*string) *ServiceInstance {
+	if s.Metadata == nil {
+		s.Metadata = &resource.Metadata{}
+	}
+	s.Metadata.Annotations = annotations
+	return s
+}

--- a/internal/clients/fake/space.go
+++ b/internal/clients/fake/space.go
@@ -99,3 +99,18 @@ func (s *Space) SetRelationships(guid string) *Space {
 	}
 	return s
 }
+
+func (s *Space) SetLabels(labels map[string]*string) *Space {
+	if s.Metadata == nil {
+		s.Metadata = &resource.Metadata{}
+	}
+	s.Metadata.Labels = labels
+	return s
+}
+func (s *Space) SetAnnotations(annotations map[string]*string) *Space {
+	if s.Metadata == nil {
+		s.Metadata = &resource.Metadata{}
+	}
+	s.Metadata.Annotations = annotations
+	return s
+}

--- a/internal/clients/metadata/metadata.go
+++ b/internal/clients/metadata/metadata.go
@@ -185,3 +185,27 @@ func DiffMetadata(desiredLabels, desiredAnnotations, actualLabels, actualAnnotat
 	m.Annotations = diffMap(desiredAnnotations, actualAnnotations)
 	return m
 }
+
+// StripDefaultLabels removes Crossplane default label keys from a label map.
+// The default labels (crossplane-kind, crossplane-name, crossplane-providerconfig)
+// are infrastructure metadata computed by the controller from the CR identity.
+// They should not be late-initialized into spec.ForProvider.Labels because
+// the controller recomputes them on every reconcile via BuildMetadata.
+func StripDefaultLabels(labels map[string]*string) map[string]*string {
+	if labels == nil {
+		return nil
+	}
+	result := make(map[string]*string, len(labels))
+	for k, v := range labels {
+		if k == resource.ExternalResourceTagKeyKind ||
+			k == resource.ExternalResourceTagKeyName ||
+			k == resource.ExternalResourceTagKeyProvider {
+			continue
+		}
+		result[k] = v
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}

--- a/internal/clients/org/org.go
+++ b/internal/clients/org/org.go
@@ -7,9 +7,11 @@ import (
 	"github.com/SAP/crossplane-provider-cloudfoundry/apis/resources/v1alpha1"
 	"github.com/SAP/crossplane-provider-cloudfoundry/internal/clients"
 	"github.com/SAP/crossplane-provider-cloudfoundry/internal/clients/job"
+	"github.com/SAP/crossplane-provider-cloudfoundry/internal/clients/metadata"
 
 	"github.com/cloudfoundry/go-cfclient/v3/client"
 	"github.com/cloudfoundry/go-cfclient/v3/resource"
+	xpresource "github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/google/uuid"
 	"k8s.io/utils/ptr"
 )
@@ -62,14 +64,11 @@ func GetOrgByGUID(ctx context.Context, c Client, guid string) (*resource.Organiz
 }
 
 // GenerateCreate generates the OrganizationCreate from an *OrgParameters
-func GenerateCreate(spec v1alpha1.OrgParameters) *resource.OrganizationCreate {
-	// if external-name is not set, search by Name and Space
+func GenerateCreate(mg xpresource.Managed, spec v1alpha1.OrgParameters) *resource.OrganizationCreate {
 	create := &resource.OrganizationCreate{}
 	create.Name = spec.Name
 	create.Suspended = spec.Suspended
-
-	// TODO: ADD labels and annotations
-
+	create.Metadata = metadata.BuildMetadata(mg, spec.Labels, spec.Annotations)
 	return create
 }
 
@@ -83,8 +82,8 @@ func GenerateObservation(o *resource.Organization) v1alpha1.OrgObservation {
 	}
 
 	if o.Metadata != nil {
-		obs.Annotations = o.Metadata.Annotations
 		obs.Labels = o.Metadata.Labels
+		obs.Annotations = o.Metadata.Annotations
 	}
 
 	if o.Relationships.Quota.Data != nil {
@@ -103,13 +102,27 @@ func LateInitialize(spec *v1alpha1.OrgParameters, from *resource.Organization) {
 	if spec.Suspended == nil {
 		spec.Suspended = ptr.To(from.Suspended)
 	}
-	// TODO: ADD labels and annotations
+
+	if len(spec.Labels) == 0 && from.Metadata != nil {
+		spec.Labels = metadata.StripDefaultLabels(from.Metadata.Labels)
+	}
+
+	if len(spec.Annotations) == 0 && from.Metadata != nil {
+		spec.Annotations = from.Metadata.Annotations
+	}
 }
 
 // IsUpToDate checks whether current state is up-to-date compared to the given
 // set of parameters.
-func IsUpToDate(spec v1alpha1.OrgParameters, observed *resource.Organization) bool {
-	// return always true, as for now the Org resource is observe only
-
-	return spec.Name == observed.Name
+func IsUpToDate(mg xpresource.Managed, spec v1alpha1.OrgParameters, observed *resource.Organization) bool {
+	if spec.Name != observed.Name {
+		return false
+	}
+	desired := metadata.BuildMetadata(mg, spec.Labels, spec.Annotations)
+	var actualLabels, actualAnnotations map[string]*string
+	if observed.Metadata != nil {
+		actualLabels = observed.Metadata.Labels
+		actualAnnotations = observed.Metadata.Annotations
+	}
+	return metadata.IsMetadataUpToDate(desired.Labels, desired.Annotations, actualLabels, actualAnnotations)
 }

--- a/internal/clients/route/route.go
+++ b/internal/clients/route/route.go
@@ -3,14 +3,17 @@ package route
 import (
 	"context"
 	"fmt"
+
 	"time"
 
 	"github.com/cloudfoundry/go-cfclient/v3/client"
 	"github.com/cloudfoundry/go-cfclient/v3/resource"
+	xpresource "github.com/crossplane/crossplane-runtime/pkg/resource"
 
 	"github.com/SAP/crossplane-provider-cloudfoundry/apis/resources/v1alpha1"
 	"github.com/SAP/crossplane-provider-cloudfoundry/internal/clients"
 	"github.com/SAP/crossplane-provider-cloudfoundry/internal/clients/job"
+	"github.com/SAP/crossplane-provider-cloudfoundry/internal/clients/metadata"
 )
 
 // Route is the interface that defines the methods that a Route client should implement.
@@ -64,8 +67,8 @@ func (c *Client) GetRouteByGUID(ctx context.Context, guid string) (*v1alpha1.Rou
 }
 
 // Create creates a Route and returns the GUID or error
-func (c *Client) Create(ctx context.Context, forProvider v1alpha1.RouteParameters) (string, error) {
-	opts, err := FormatCreateOption(forProvider)
+func (c *Client) Create(ctx context.Context, mg xpresource.Managed, forProvider v1alpha1.RouteParameters) (string, error) {
+	opts, err := FormatCreateOption(mg, forProvider)
 	if err != nil {
 		return "", err
 	}
@@ -78,12 +81,12 @@ func (c *Client) Create(ctx context.Context, forProvider v1alpha1.RouteParameter
 }
 
 // Update updates a Route
-func (c *Client) Update(ctx context.Context, guid string, forProvider v1alpha1.RouteParameters) error {
+func (c *Client) Update(ctx context.Context, guid string, mg xpresource.Managed, forProvider v1alpha1.RouteParameters) error {
 	if !clients.IsValidGUID(guid) {
 		return fmt.Errorf("invalid Route GUID")
 	}
 
-	opts := FormatUpdateOption(forProvider)
+	opts := FormatUpdateOption(mg, forProvider)
 	if opts == nil {
 		return fmt.Errorf("invalid Route parameters")
 	}
@@ -133,7 +136,7 @@ func FormatListOption(forProvider v1alpha1.RouteParameters) (*client.RouteListOp
 }
 
 // FormatCreateOption generates the RouteCreate from the forProvider spec
-func FormatCreateOption(forProvider v1alpha1.RouteParameters) (*resource.RouteCreate, error) {
+func FormatCreateOption(mg xpresource.Managed, forProvider v1alpha1.RouteParameters) (*resource.RouteCreate, error) {
 	if forProvider.Space == nil || forProvider.Domain == nil {
 		return nil, fmt.Errorf("space and domain are required")
 	}
@@ -152,25 +155,26 @@ func FormatCreateOption(forProvider v1alpha1.RouteParameters) (*resource.RouteCr
 		opts.Port = forProvider.Port
 	}
 
+	opts.Metadata = metadata.BuildMetadata(mg, forProvider.Labels, forProvider.Annotations)
 	return opts, nil
 }
 
-// FormatUpdateOption generates the RouteCreate from an *RouteParameters
-func FormatUpdateOption(forProvider v1alpha1.RouteParameters) *resource.RouteUpdate {
+// FormatUpdateOption generates the RouteUpdate from an *RouteParameters
+func FormatUpdateOption(mg xpresource.Managed, forProvider v1alpha1.RouteParameters) *resource.RouteUpdate {
 	// client supports only updating metadata
 	return &resource.RouteUpdate{
-		Metadata: &resource.Metadata{},
+		Metadata: metadata.BuildMetadata(mg, forProvider.Labels, forProvider.Annotations),
 	}
 }
 
 // GenerateObservation takes an Route resource and returns *RouteObservation.
 func GenerateObservation(o *resource.Route) v1alpha1.RouteObservation {
-	resource := v1alpha1.Resource{
+	res := v1alpha1.Resource{
 		GUID:      o.GUID,
 		CreatedAt: strToPtr(o.CreatedAt.Format(time.RFC3339)),
 		UpdatedAt: strToPtr(o.UpdatedAt.Format(time.RFC3339)),
 	}
-	obs := v1alpha1.RouteObservation{Resource: resource}
+	obs := v1alpha1.RouteObservation{Resource: res}
 
 	obs.URL = strToPtr(o.URL)
 	obs.Host = strToPtr(o.Host)
@@ -203,14 +207,20 @@ func GenerateObservation(o *resource.Route) v1alpha1.RouteObservation {
 
 		}
 	}
+
+	if o.Metadata != nil {
+		obs.Labels = o.Metadata.Labels
+		obs.Annotations = o.Metadata.Annotations
+	}
 	return obs
 }
 
 // IsUpToDate checks whether current state is up-to-date compared to the given
 // set of parameters.
-func IsUpToDate(forProvider v1alpha1.RouteParameters, atProvider v1alpha1.RouteObservation) bool {
-	// Routes are mostly immutable, expect for metadata
-	return true
+func IsUpToDate(mg xpresource.Managed, forProvider v1alpha1.RouteParameters, atProvider v1alpha1.RouteObservation) bool {
+	// Routes are mostly immutable, except for metadata
+	desired := metadata.BuildMetadata(mg, forProvider.Labels, forProvider.Annotations)
+	return metadata.IsMetadataUpToDate(desired.Labels, desired.Annotations, atProvider.Labels, atProvider.Annotations)
 }
 
 func strToPtr(s string) *string {

--- a/internal/clients/route/route_test.go
+++ b/internal/clients/route/route_test.go
@@ -5,9 +5,9 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-
 	"github.com/cloudfoundry/go-cfclient/v3/client"
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/utils/ptr"
 
 	"github.com/SAP/crossplane-provider-cloudfoundry/apis/resources/v1alpha1"
 	"github.com/SAP/crossplane-provider-cloudfoundry/internal/clients/fake"
@@ -313,7 +313,7 @@ func TestCreate(t *testing.T) {
 				Route: tc.service(),
 			}
 
-			id, err := c.Create(context.Background(), tc.args.forProvider)
+			id, err := c.Create(context.Background(), nil, tc.args.forProvider)
 
 			if tc.want.err != nil && err != nil {
 				if diff := cmp.Diff(tc.want.err.Error(), err.Error()); diff != "" {
@@ -432,6 +432,86 @@ func TestDelete(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.want.jobGUID, jobGUID); diff != "" {
 				t.Errorf("Delete(...): -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestIsUpToDate(t *testing.T) {
+	cases := map[string]struct {
+		forProvider v1alpha1.RouteParameters
+		atProvider  v1alpha1.RouteObservation
+		want        bool
+	}{
+		"UpToDate no labels": {
+			forProvider: v1alpha1.RouteParameters{},
+			atProvider:  v1alpha1.RouteObservation{},
+			want:        true,
+		},
+		"Label drift - spec has labels but observation does not": {
+			forProvider: v1alpha1.RouteParameters{
+				ResourceMetadata: v1alpha1.ResourceMetadata{
+					Labels: map[string]*string{"env": ptr.To("prod")},
+				},
+			},
+			atProvider: v1alpha1.RouteObservation{},
+			want:       false,
+		},
+		"Labels match": {
+			forProvider: v1alpha1.RouteParameters{
+				ResourceMetadata: v1alpha1.ResourceMetadata{
+					Labels: map[string]*string{"env": ptr.To("prod")},
+				},
+			},
+			atProvider: v1alpha1.RouteObservation{
+				ResourceMetadata: v1alpha1.ResourceMetadata{
+					Labels: map[string]*string{"env": ptr.To("prod")},
+				},
+			},
+			want: true,
+		},
+		"Annotation drift - spec has annotations but observation does not": {
+			forProvider: v1alpha1.RouteParameters{
+				ResourceMetadata: v1alpha1.ResourceMetadata{
+					Annotations: map[string]*string{"note": ptr.To("value")},
+				},
+			},
+			atProvider: v1alpha1.RouteObservation{},
+			want:       false,
+		},
+		"Annotations match": {
+			forProvider: v1alpha1.RouteParameters{
+				ResourceMetadata: v1alpha1.ResourceMetadata{
+					Annotations: map[string]*string{"note": ptr.To("value")},
+				},
+			},
+			atProvider: v1alpha1.RouteObservation{
+				ResourceMetadata: v1alpha1.ResourceMetadata{
+					Annotations: map[string]*string{"note": ptr.To("value")},
+				},
+			},
+			want: true,
+		},
+		"Extra observed labels are ok - subset check": {
+			forProvider: v1alpha1.RouteParameters{
+				ResourceMetadata: v1alpha1.ResourceMetadata{
+					Labels: map[string]*string{"env": ptr.To("prod")},
+				},
+			},
+			atProvider: v1alpha1.RouteObservation{
+				ResourceMetadata: v1alpha1.ResourceMetadata{
+					Labels: map[string]*string{"env": ptr.To("prod"), "extra": ptr.To("other")},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for n, tc := range cases {
+		t.Run(n, func(t *testing.T) {
+			result := IsUpToDate(nil, tc.forProvider, tc.atProvider)
+			if result != tc.want {
+				t.Errorf("IsUpToDate(...): want %v, got %v", tc.want, result)
 			}
 		})
 	}

--- a/internal/clients/servicecredentialbinding/servicecredentialbinding.go
+++ b/internal/clients/servicecredentialbinding/servicecredentialbinding.go
@@ -12,10 +12,12 @@ import (
 	"github.com/cloudfoundry/go-cfclient/v3/client"
 	"github.com/cloudfoundry/go-cfclient/v3/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
+	xpresource "github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/google/uuid"
 
 	"github.com/SAP/crossplane-provider-cloudfoundry/apis/resources/v1alpha1"
 	"github.com/SAP/crossplane-provider-cloudfoundry/internal/clients/job"
+	"github.com/SAP/crossplane-provider-cloudfoundry/internal/clients/metadata"
 )
 
 const (
@@ -64,8 +66,8 @@ func GetByIDOrSearch(ctx context.Context, scbClient ServiceCredentialBinding, gu
 }
 
 // Create creates a ServiceCredentialBinding resource
-func Create(ctx context.Context, scbClient ServiceCredentialBinding, forProvider v1alpha1.ServiceCredentialBindingParameters, params json.RawMessage) (*resource.ServiceCredentialBinding, error) {
-	opt, err := newCreateOption(forProvider, params)
+func Create(ctx context.Context, scbClient ServiceCredentialBinding, mg xpresource.Managed, forProvider v1alpha1.ServiceCredentialBindingParameters, params json.RawMessage) (*resource.ServiceCredentialBinding, error) {
+	opt, err := newCreateOption(mg, forProvider, params)
 	if err != nil {
 		return nil, err
 	}
@@ -86,8 +88,8 @@ func Create(ctx context.Context, scbClient ServiceCredentialBinding, forProvider
 }
 
 // Update updates labels and annotations of a ServiceCredentialBinding resource
-func Update(ctx context.Context, scbClient ServiceCredentialBinding, guid string, forProvider v1alpha1.ServiceCredentialBindingParameters) (*resource.ServiceCredentialBinding, error) {
-	opt := newUpdateOption(forProvider)
+func Update(ctx context.Context, scbClient ServiceCredentialBinding, guid string, mg xpresource.Managed, forProvider v1alpha1.ServiceCredentialBindingParameters) (*resource.ServiceCredentialBinding, error) {
+	opt := newUpdateOption(mg, forProvider)
 	return scbClient.Update(ctx, guid, opt)
 }
 
@@ -150,7 +152,7 @@ func newListOptions(forProvider v1alpha1.ServiceCredentialBindingParameters) (*c
 }
 
 // newCreateOption generates ServiceCredentialBindingCreate according to CR's ForProvider spec
-func newCreateOption(forProvider v1alpha1.ServiceCredentialBindingParameters, params json.RawMessage) (*resource.ServiceCredentialBindingCreate, error) {
+func newCreateOption(mg xpresource.Managed, forProvider v1alpha1.ServiceCredentialBindingParameters, params json.RawMessage) (*resource.ServiceCredentialBindingCreate, error) {
 	if forProvider.ServiceInstance == nil {
 		return nil, errors.New(ErrServiceInstanceMissing)
 	}
@@ -182,6 +184,7 @@ func newCreateOption(forProvider v1alpha1.ServiceCredentialBindingParameters, pa
 	if params != nil {
 		opt.WithJSONParameters(string(params))
 	}
+	opt.Metadata = metadata.BuildMetadata(mg, forProvider.Labels, forProvider.Annotations)
 	return opt, nil
 }
 
@@ -204,9 +207,9 @@ func createToListOptions(create *resource.ServiceCredentialBindingCreate) *clien
 }
 
 // newUpdateOption generates ServiceCredentialBindingUpdate according to CR's ForProvider spec
-func newUpdateOption(forProvider v1alpha1.ServiceCredentialBindingParameters) *resource.ServiceCredentialBindingUpdate {
+func newUpdateOption(mg xpresource.Managed, forProvider v1alpha1.ServiceCredentialBindingParameters) *resource.ServiceCredentialBindingUpdate {
 	opt := &resource.ServiceCredentialBindingUpdate{}
-	// TODO: implement update option. SCB support only updates for labels and annotations. No other fields can be updated. Labels and annotations are not supported yet, so for now we return an empty update option.
+	opt.Metadata = metadata.BuildMetadata(mg, forProvider.Labels, forProvider.Annotations)
 	return opt
 }
 
@@ -220,12 +223,23 @@ func UpdateObservation(observation *v1alpha1.ServiceCredentialBindingObservation
 		UpdatedAt:   r.LastOperation.UpdatedAt.String(),
 		CreatedAt:   r.LastOperation.CreatedAt.String(),
 	}
+
+	if r.Metadata != nil {
+		observation.Labels = r.Metadata.Labels
+		observation.Annotations = r.Metadata.Annotations
+	}
 }
 
 // IsUpToDate checks whether the CR is up to date with the observed resource
-func IsUpToDate(ctx context.Context, forProvider v1alpha1.ServiceCredentialBindingParameters, r resource.ServiceCredentialBinding) bool {
-	// SCB support updates for labels and metadata only. This is to be implemented. For now return true
-	return true
+func IsUpToDate(ctx context.Context, mg xpresource.Managed, forProvider v1alpha1.ServiceCredentialBindingParameters, r resource.ServiceCredentialBinding) bool {
+	// SCB supports updates for labels and annotations only
+	desired := metadata.BuildMetadata(mg, forProvider.Labels, forProvider.Annotations)
+	var actualLabels, actualAnnotations map[string]*string
+	if r.Metadata != nil {
+		actualLabels = r.Metadata.Labels
+		actualAnnotations = r.Metadata.Annotations
+	}
+	return metadata.IsMetadataUpToDate(desired.Labels, desired.Annotations, actualLabels, actualAnnotations)
 }
 
 func randomName(name string) string {

--- a/internal/clients/servicecredentialbinding/servicecredentialbinding_test.go
+++ b/internal/clients/servicecredentialbinding/servicecredentialbinding_test.go
@@ -7,13 +7,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/stretchr/testify/mock"
-
-	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
-
 	"github.com/cloudfoundry/go-cfclient/v3/client"
 	cfresource "github.com/cloudfoundry/go-cfclient/v3/resource"
+	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/mock"
+	"k8s.io/utils/ptr"
 
 	"github.com/SAP/crossplane-provider-cloudfoundry/apis/resources/v1alpha1"
 	"github.com/SAP/crossplane-provider-cloudfoundry/internal/clients/fake"
@@ -351,7 +350,7 @@ func TestNewCreateOption(t *testing.T) {
 
 	for n, tc := range cases {
 		t.Run(n, func(t *testing.T) {
-			opt, err := newCreateOption(tc.args.forProvider, tc.args.params)
+			opt, err := newCreateOption(nil, tc.args.forProvider, tc.args.params)
 
 			if tc.want.err != nil && err != nil {
 				if diff := cmp.Diff(tc.want.err.Error(), err.Error()); diff != "" {
@@ -414,8 +413,8 @@ func TestIsUpToDate(t *testing.T) {
 		Resource: cfresource.Resource{GUID: testGUID},
 	}
 
-	// Currently always returns true as per implementation
-	result := IsUpToDate(context.Background(), forProvider, resource)
+	// With nil mg and no labels, metadata check returns true
+	result := IsUpToDate(context.Background(), nil, forProvider, resource)
 	if !result {
 		t.Errorf("IsUpToDate(...): expected true, got false")
 	}
@@ -438,4 +437,100 @@ func createMockClientWithDetails(credentials map[string]interface{}, err error) 
 	}
 
 	return mockClient
+}
+
+func TestIsUpToDate_Metadata(t *testing.T) {
+	cases := map[string]struct {
+		forProvider v1alpha1.ServiceCredentialBindingParameters
+		observed    cfresource.ServiceCredentialBinding
+		want        bool
+	}{
+		"UpToDate no labels": {
+			forProvider: v1alpha1.ServiceCredentialBindingParameters{
+				Type: "key",
+				Name: ptr.To("test-binding"),
+			},
+			observed: cfresource.ServiceCredentialBinding{
+				Resource: cfresource.Resource{GUID: testGUID},
+			},
+			want: true,
+		},
+		"Label drift - spec has labels but observed does not": {
+			forProvider: v1alpha1.ServiceCredentialBindingParameters{
+				Type: "key",
+				Name: ptr.To("test-binding"),
+				ResourceMetadata: v1alpha1.ResourceMetadata{
+					Labels: map[string]*string{"env": ptr.To("prod")},
+				},
+			},
+			observed: cfresource.ServiceCredentialBinding{
+				Resource: cfresource.Resource{GUID: testGUID},
+			},
+			want: false,
+		},
+		"Labels match": {
+			forProvider: v1alpha1.ServiceCredentialBindingParameters{
+				Type: "key",
+				Name: ptr.To("test-binding"),
+				ResourceMetadata: v1alpha1.ResourceMetadata{
+					Labels: map[string]*string{"env": ptr.To("prod")},
+				},
+			},
+			observed: cfresource.ServiceCredentialBinding{
+				Resource: cfresource.Resource{GUID: testGUID},
+				Metadata: &cfresource.Metadata{
+					Labels: map[string]*string{"env": ptr.To("prod")},
+				},
+			},
+			want: true,
+		},
+		"Annotation drift - spec has annotations but observed does not": {
+			forProvider: v1alpha1.ServiceCredentialBindingParameters{
+				Type: "key",
+				Name: ptr.To("test-binding"),
+				ResourceMetadata: v1alpha1.ResourceMetadata{
+					Annotations: map[string]*string{"note": ptr.To("value")},
+				},
+			},
+			observed: cfresource.ServiceCredentialBinding{
+				Resource: cfresource.Resource{GUID: testGUID},
+			},
+			want: false,
+		},
+		"Annotations match": {
+			forProvider: v1alpha1.ServiceCredentialBindingParameters{
+				Type: "key",
+				Name: ptr.To("test-binding"),
+				ResourceMetadata: v1alpha1.ResourceMetadata{
+					Annotations: map[string]*string{"note": ptr.To("value")},
+				},
+			},
+			observed: cfresource.ServiceCredentialBinding{
+				Resource: cfresource.Resource{GUID: testGUID},
+				Metadata: &cfresource.Metadata{
+					Annotations: map[string]*string{"note": ptr.To("value")},
+				},
+			},
+			want: true,
+		},
+		"Observed nil metadata": {
+			forProvider: v1alpha1.ServiceCredentialBindingParameters{
+				Type: "key",
+				Name: ptr.To("test-binding"),
+			},
+			observed: cfresource.ServiceCredentialBinding{
+				Resource: cfresource.Resource{GUID: testGUID},
+			},
+			want: true,
+		},
+	}
+
+	for n, tc := range cases {
+		t.Run(n, func(t *testing.T) {
+			result := IsUpToDate(context.Background(), nil, tc.forProvider, tc.observed)
+			if result != tc.want {
+				t.Errorf("IsUpToDate(...): want %v, got %v", tc.want, result)
+			}
+		})
+	}
 }

--- a/internal/clients/serviceinstance/serviceinstance.go
+++ b/internal/clients/serviceinstance/serviceinstance.go
@@ -8,12 +8,14 @@ import (
 
 	"github.com/cloudfoundry/go-cfclient/v3/client"
 	"github.com/cloudfoundry/go-cfclient/v3/resource"
+	xpresource "github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"k8s.io/utils/ptr"
 
 	"github.com/SAP/crossplane-provider-cloudfoundry/apis/resources/v1alpha1"
 	"github.com/SAP/crossplane-provider-cloudfoundry/internal/clients"
+	"github.com/SAP/crossplane-provider-cloudfoundry/internal/clients/metadata"
 )
 
 // ServiceInstance defines interfaces to the ServiceInstance resource
@@ -150,20 +152,20 @@ func (c *Client) GetServiceCredentials(ctx context.Context, r *resource.ServiceI
 }
 
 // Create creates the external resource according to CR's ForProvider spec
-func (c *Client) Create(ctx context.Context, spec v1alpha1.ServiceInstanceParameters, creds json.RawMessage) (*resource.ServiceInstance, error) {
+func (c *Client) Create(ctx context.Context, mg xpresource.Managed, spec v1alpha1.ServiceInstanceParameters, creds json.RawMessage) (*resource.ServiceInstance, error) {
 	switch spec.Type {
 	case v1alpha1.ManagedService:
-		return c.createManaged(ctx, spec, creds)
+		return c.createManaged(ctx, mg, spec, creds)
 
 	case v1alpha1.UserProvidedService:
-		return c.createUserProvided(ctx, spec, creds)
+		return c.createUserProvided(ctx, mg, spec, creds)
 	default:
 		return nil, errors.New("unknown service instance type")
 	}
 }
 
 // createManaged creates a managed service instance according to CR's ForProvider spec
-func (c *Client) createManaged(ctx context.Context, spec v1alpha1.ServiceInstanceParameters, params json.RawMessage) (*resource.ServiceInstance, error) {
+func (c *Client) createManaged(ctx context.Context, mg xpresource.Managed, spec v1alpha1.ServiceInstanceParameters, params json.RawMessage) (*resource.ServiceInstance, error) {
 
 	// throw error if no space is provided
 	if spec.Space == nil {
@@ -171,6 +173,7 @@ func (c *Client) createManaged(ctx context.Context, spec v1alpha1.ServiceInstanc
 	}
 
 	opt := resource.NewServiceInstanceCreateManaged(*spec.Name, *spec.Space, *spec.ServicePlan.ID)
+	opt.Metadata = metadata.BuildMetadata(mg, spec.Labels, spec.Annotations)
 
 	if params != nil {
 		opt.Parameters = &params
@@ -189,13 +192,14 @@ func (c *Client) createManaged(ctx context.Context, spec v1alpha1.ServiceInstanc
 }
 
 // createUserProvided creates a user-provided service instance according to CR's ForProvider spec
-func (c *Client) createUserProvided(ctx context.Context, spec v1alpha1.ServiceInstanceParameters, creds json.RawMessage) (*resource.ServiceInstance, error) {
+func (c *Client) createUserProvided(ctx context.Context, mg xpresource.Managed, spec v1alpha1.ServiceInstanceParameters, creds json.RawMessage) (*resource.ServiceInstance, error) {
 	// throw error if no space is provided
 	if spec.Space == nil {
 		return nil, errors.New("no space reference provided")
 	}
 	// create the service instance
 	opt := resource.NewServiceInstanceCreateUserProvided(*spec.Name, *spec.Space)
+	opt.Metadata = metadata.BuildMetadata(mg, spec.Labels, spec.Annotations)
 	si, err := c.CreateUserProvided(ctx, opt)
 	if err != nil {
 		return nil, err
@@ -213,23 +217,23 @@ func (c *Client) createUserProvided(ctx context.Context, spec v1alpha1.ServiceIn
 }
 
 // Update updates the external resource to keep it in sync with CR's ForProvider spec
-func (c *Client) Update(ctx context.Context, guid string, desired *v1alpha1.ServiceInstanceParameters, creds json.RawMessage) (*resource.ServiceInstance, error) {
+func (c *Client) Update(ctx context.Context, guid string, mg xpresource.Managed, desired *v1alpha1.ServiceInstanceParameters, creds json.RawMessage) (*resource.ServiceInstance, error) {
 	observed, err := c.Get(ctx, guid)
 	if err != nil {
 		return nil, err
 	}
 	switch desired.Type {
 	case v1alpha1.ManagedService:
-		return c.updateManaged(ctx, observed, desired, creds)
+		return c.updateManaged(ctx, observed, mg, desired, creds)
 	case v1alpha1.UserProvidedService:
-		return c.updateUserProvided(ctx, observed, desired, creds)
+		return c.updateUserProvided(ctx, observed, mg, desired, creds)
 	default:
 		return nil, errors.New("unknown service instance type")
 	}
 }
 
 // updateManaged updates managed service instance according to CR's ForProvider spec
-func (c *Client) updateManaged(ctx context.Context, observed *resource.ServiceInstance, desired *v1alpha1.ServiceInstanceParameters, params json.RawMessage) (*resource.ServiceInstance, error) {
+func (c *Client) updateManaged(ctx context.Context, observed *resource.ServiceInstance, mg xpresource.Managed, desired *v1alpha1.ServiceInstanceParameters, params json.RawMessage) (*resource.ServiceInstance, error) {
 	upd := resource.NewServiceInstanceManagedUpdate()
 
 	if observed.Name != *desired.Name {
@@ -243,6 +247,8 @@ func (c *Client) updateManaged(ctx context.Context, observed *resource.ServiceIn
 	if params != nil {
 		upd.WithParameters(params)
 	}
+
+	upd.Metadata = metadata.BuildMetadata(mg, desired.Labels, desired.Annotations)
 
 	// Update the service instance
 	job, s, err := c.UpdateManaged(ctx, observed.GUID, upd)
@@ -263,7 +269,7 @@ func (c *Client) updateManaged(ctx context.Context, observed *resource.ServiceIn
 }
 
 // updateUserProvided updates user-provided service instance according to CR's ForProvider spec
-func (c *Client) updateUserProvided(ctx context.Context, observed *resource.ServiceInstance, desired *v1alpha1.ServiceInstanceParameters, creds json.RawMessage) (*resource.ServiceInstance, error) {
+func (c *Client) updateUserProvided(ctx context.Context, observed *resource.ServiceInstance, mg xpresource.Managed, desired *v1alpha1.ServiceInstanceParameters, creds json.RawMessage) (*resource.ServiceInstance, error) {
 	upd := resource.NewServiceInstanceUserProvidedUpdate()
 
 	if observed.Name != *desired.Name {
@@ -275,6 +281,8 @@ func (c *Client) updateUserProvided(ctx context.Context, observed *resource.Serv
 	}
 	upd.WithRouteServiceURL(desired.RouteServiceURL).
 		WithSyslogDrainURL(desired.SyslogDrainURL)
+
+	upd.Metadata = metadata.BuildMetadata(mg, desired.Labels, desired.Annotations)
 
 	return c.UpdateUserProvided(ctx, observed.GUID, upd)
 }
@@ -318,10 +326,16 @@ func UpdateObservation(in *v1alpha1.ServiceInstanceObservation, r *resource.Serv
 	if r.Type == string(v1alpha1.ManagedService) {
 		in.ServicePlan = &r.Relationships.ServicePlan.Data.GUID
 	}
+
+	if r.Metadata != nil {
+		in.Labels = r.Metadata.Labels
+		in.Annotations = r.Metadata.Annotations
+	}
 }
 
-// IsUpToDate checks if the managed resource is in sync with CR.
-func IsUpToDate(in *v1alpha1.ServiceInstanceParameters, observed *resource.ServiceInstance) bool {
+// specUpToDate checks whether the spec fields (name, service plan, route service URL,
+// syslog drain URL) of a ServiceInstance are in sync with the observed CF resource.
+func specUpToDate(in *v1alpha1.ServiceInstanceParameters, observed *resource.ServiceInstance) bool {
 	if in.Name != nil && *in.Name != observed.Name {
 		return false
 	}
@@ -340,6 +354,21 @@ func IsUpToDate(in *v1alpha1.ServiceInstanceParameters, observed *resource.Servi
 		}
 	}
 	return true
+}
+
+// IsUpToDate checks if the managed resource is in sync with CR.
+func IsUpToDate(mg xpresource.Managed, in *v1alpha1.ServiceInstanceParameters, observed *resource.ServiceInstance) bool {
+	if !specUpToDate(in, observed) {
+		return false
+	}
+
+	desired := metadata.BuildMetadata(mg, in.Labels, in.Annotations)
+	var actualLabels, actualAnnotations map[string]*string
+	if observed.Metadata != nil {
+		actualLabels = observed.Metadata.Labels
+		actualAnnotations = observed.Metadata.Annotations
+	}
+	return metadata.IsMetadataUpToDate(desired.Labels, desired.Annotations, actualLabels, actualAnnotations)
 }
 
 // AreSharedSpacesUpToDate checks if the shared spaces of a service instance are in sync with the CR

--- a/internal/clients/serviceroutebinding/serviceroutebinding.go
+++ b/internal/clients/serviceroutebinding/serviceroutebinding.go
@@ -77,16 +77,11 @@ func createToListOptions(create *resource.ServiceRouteBindingCreate) *client.Ser
 	return opts
 }
 
-func Update(ctx context.Context, srbClient ServiceRouteBinding, guid string, forProvider v1alpha1.ServiceRouteBindingParameters) (*resource.ServiceRouteBinding, error) {
+func Update(ctx context.Context, srbClient ServiceRouteBinding, guid string, mg xpresource.Managed, forProvider v1alpha1.ServiceRouteBindingParameters) (*resource.ServiceRouteBinding, error) {
 	update := &resource.ServiceRouteBindingUpdate{}
 
 	// ServiceRouteBindings only support updating metadata (labels and annotations)
-	if forProvider.Labels != nil || forProvider.Annotations != nil {
-		update.Metadata = &resource.Metadata{
-			Labels:      forProvider.Labels,
-			Annotations: forProvider.Annotations,
-		}
-	}
+	update.Metadata = metadata.BuildMetadata(mg, forProvider.Labels, forProvider.Annotations)
 
 	return srbClient.Update(ctx, guid, update)
 }

--- a/internal/clients/space/space.go
+++ b/internal/clients/space/space.go
@@ -6,9 +6,11 @@ import (
 
 	"github.com/cloudfoundry/go-cfclient/v3/client"
 	"github.com/cloudfoundry/go-cfclient/v3/resource"
+	xpresource "github.com/crossplane/crossplane-runtime/pkg/resource"
 	"k8s.io/utils/ptr"
 
 	"github.com/SAP/crossplane-provider-cloudfoundry/apis/resources/v1alpha1"
+	"github.com/SAP/crossplane-provider-cloudfoundry/internal/clients/metadata"
 	"github.com/SAP/crossplane-provider-cloudfoundry/internal/clients/org"
 )
 
@@ -58,20 +60,22 @@ func GenerateListOption(spec v1alpha1.SpaceParameters) *client.SpaceListOptions 
 }
 
 // GenerateCreate generates the SpaceCreate from an *SpaceParameters
-func GenerateCreate(spec v1alpha1.SpaceParameters) *resource.SpaceCreate {
+func GenerateCreate(mg xpresource.Managed, spec v1alpha1.SpaceParameters) *resource.SpaceCreate {
 	org := ptr.Deref(spec.Org, "")
-	return resource.NewSpaceCreate(spec.Name, org)
+	create := resource.NewSpaceCreate(spec.Name, org)
+	create.Metadata = metadata.BuildMetadata(mg, spec.Labels, spec.Annotations)
+	return create
 }
 
-// GenerateUpdate generates the SpaceCreate from an *SpaceParameters
-func GenerateUpdate(spec v1alpha1.SpaceParameters) *resource.SpaceUpdate {
+// GenerateUpdate generates the SpaceUpdate from an *SpaceParameters
+func GenerateUpdate(mg xpresource.Managed, spec v1alpha1.SpaceParameters) *resource.SpaceUpdate {
 	return &resource.SpaceUpdate{
 		Name:     spec.Name,
-		Metadata: &resource.Metadata{},
+		Metadata: metadata.BuildMetadata(mg, spec.Labels, spec.Annotations),
 	}
 }
 
-// GenerateObservation takes an Space resource and returns *SpaceObservation.
+// GenerateObservation takes a Space resource and returns *SpaceObservation.
 func GenerateObservation(o *resource.Space, ssh bool) v1alpha1.SpaceObservation {
 	obs := v1alpha1.SpaceObservation{
 		ID:        o.GUID,
@@ -85,8 +89,8 @@ func GenerateObservation(o *resource.Space, ssh bool) v1alpha1.SpaceObservation 
 		obs.Quota = ptr.To(o.Relationships.Quota.Data.GUID)
 	}
 	if o.Metadata != nil {
-		obs.Annotations = o.Metadata.Annotations
 		obs.Labels = o.Metadata.Labels
+		obs.Annotations = o.Metadata.Annotations
 	}
 	return obs
 }
@@ -99,10 +103,15 @@ func LateInitialize(cr *v1alpha1.Space, from *resource.Space, ssh bool) bool {
 
 // IsUpToDate checks whether current state is up-to-date compared to the given
 // set of parameters.
-func IsUpToDate(spec v1alpha1.SpaceParameters, observed *resource.Space, ssh bool) bool {
-	// rename or update ssh setting
-	return spec.Name == observed.Name && (spec.AllowSSH == ssh)
-
+func IsUpToDate(mg xpresource.Managed, spec v1alpha1.SpaceParameters, observed *resource.Space, ssh bool) bool {
+	upToDate := spec.Name == observed.Name && (spec.AllowSSH == ssh)
+	desired := metadata.BuildMetadata(mg, spec.Labels, spec.Annotations)
+	var actualLabels, actualAnnotations map[string]*string
+	if observed.Metadata != nil {
+		actualLabels = observed.Metadata.Labels
+		actualAnnotations = observed.Metadata.Annotations
+	}
+	return upToDate && metadata.IsMetadataUpToDate(desired.Labels, desired.Annotations, actualLabels, actualAnnotations)
 }
 
 // IsSSHEnabled checks whether SSH is enabled for the given space.

--- a/internal/controller/app/controller.go
+++ b/internal/controller/app/controller.go
@@ -171,7 +171,7 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 		cr.SetConditions(xpv1.Unavailable())
 	}
 
-	isUpToDate, err := app.IsUpToDate(cr.Spec.ForProvider, cr.Status.AtProvider)
+	isUpToDate, err := app.IsUpToDate(cr, cr.Spec.ForProvider, cr.Status.AtProvider)
 	if err != nil {
 		return managed.ExternalObservation{}, err
 	}
@@ -197,7 +197,7 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 
 	cr.SetConditions(xpv1.Creating())
 
-	application, err := c.client.CreateAndPush(ctx, cr.Spec.ForProvider, dockerCredentials)
+	application, err := c.client.CreateAndPush(ctx, cr, cr.Spec.ForProvider, dockerCredentials)
 	if err != nil {
 		return managed.ExternalCreation{}, errors.Wrap(err, errCreateResource)
 	}
@@ -228,12 +228,12 @@ func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 		if err != nil {
 			return managed.ExternalUpdate{}, errors.Wrap(err, errSecret)
 		}
-		_, err = c.client.UpdateAndPush(ctx, guid, cr.Spec.ForProvider, dockerCredentials)
+		_, err = c.client.UpdateAndPush(ctx, guid, cr, cr.Spec.ForProvider, dockerCredentials)
 		if err != nil {
 			return managed.ExternalUpdate{}, errors.Wrap(err, errUpdateResource)
 		}
 	} else if changes.HasChanges() {
-		_, err := c.client.Update(ctx, guid, cr.Spec.ForProvider)
+		_, err := c.client.Update(ctx, guid, cr, cr.Spec.ForProvider)
 		if err != nil {
 			return managed.ExternalUpdate{}, errors.Wrap(err, errUpdateResource)
 		}

--- a/internal/controller/app/controller_test.go
+++ b/internal/controller/app/controller_test.go
@@ -5,16 +5,16 @@ import (
 	"testing"
 
 	cfresource "github.com/cloudfoundry/go-cfclient/v3/resource"
-	"github.com/google/go-cmp/cmp"
-	"github.com/pkg/errors"
-	k8s "sigs.k8s.io/controller-runtime/pkg/client"
-
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	k8s "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/SAP/crossplane-provider-cloudfoundry/apis/resources/v1alpha1"
 	"github.com/SAP/crossplane-provider-cloudfoundry/internal/clients/app"
@@ -100,6 +100,12 @@ func newMockPush() *fake.MockPush {
 
 }
 
+func withDefaultMetadataLabels() modifier {
+	return func(r *v1alpha1.App) {
+		r.SetGroupVersionKind(v1alpha1.App_GroupVersionKind)
+	}
+}
+
 func TestObserve(t *testing.T) {
 	type service func() *fake.MockApp
 	type args struct {
@@ -180,7 +186,7 @@ func TestObserve(t *testing.T) {
 			},
 			want: want{
 				mg:  newApp("docker", withExternalName(guid), withSpace(spaceGUID)),
-				obs: managed.ExternalObservation{ResourceExists: true, ResourceUpToDate: true, ResourceLateInitialized: true},
+				obs: managed.ExternalObservation{ResourceExists: true, ResourceUpToDate: false, ResourceLateInitialized: true},
 				err: nil,
 			},
 			service: func() *fake.MockApp {
@@ -222,7 +228,7 @@ func TestObserve(t *testing.T) {
 		},
 		"Successful": {
 			args: args{
-				mg: newApp("docker", withExternalName(guid), withSpace(spaceGUID)),
+				mg: newApp("docker", withExternalName(guid), withSpace(spaceGUID), withDefaultMetadataLabels()),
 			},
 			want: want{
 				mg: newApp("docker",
@@ -236,11 +242,17 @@ func TestObserve(t *testing.T) {
 			service: func() *fake.MockApp {
 				m := &fake.MockApp{}
 				m.On("Get", guid).Return(
-					&fake.NewApp("docker").SetName(name).SetGUID(guid).App,
+					&fake.NewApp("docker").SetName(name).SetGUID(guid).SetLabels(map[string]*string{
+						"crossplane-kind": ptr.To("app.cloudfoundry.crossplane.io"),
+						"crossplane-name": ptr.To("my-app"),
+					}).App,
 					nil,
 				)
 				m.On("Single").Return(
-					&fake.NewApp("docker").SetName(name).SetGUID(guid).App,
+					&fake.NewApp("docker").SetName(name).SetGUID(guid).SetLabels(map[string]*string{
+						"crossplane-kind": ptr.To("app.cloudfoundry.crossplane.io"),
+						"crossplane-name": ptr.To("my-app"),
+					}).App,
 					nil,
 				)
 				return m
@@ -248,7 +260,7 @@ func TestObserve(t *testing.T) {
 		},
 		"RoutesPopulated": {
 			args: args{
-				mg: newApp("docker", withExternalName(guid), withSpace(spaceGUID)),
+				mg: newApp("docker", withExternalName(guid), withSpace(spaceGUID), withDefaultMetadataLabels()),
 			},
 			want: want{
 				mg: newApp("docker",
@@ -267,11 +279,17 @@ func TestObserve(t *testing.T) {
 			service: func() *fake.MockApp {
 				m := &fake.MockApp{}
 				m.On("Get", guid).Return(
-					&fake.NewApp("docker").SetName(name).SetGUID(guid).App,
+					&fake.NewApp("docker").SetName(name).SetGUID(guid).SetLabels(map[string]*string{
+						"crossplane-kind": ptr.To("app.cloudfoundry.crossplane.io"),
+						"crossplane-name": ptr.To("my-app"),
+					}).App,
 					nil,
 				)
 				m.On("Single").Return(
-					&fake.NewApp("docker").SetName(name).SetGUID(guid).App,
+					&fake.NewApp("docker").SetName(name).SetGUID(guid).SetLabels(map[string]*string{
+						"crossplane-kind": ptr.To("app.cloudfoundry.crossplane.io"),
+						"crossplane-name": ptr.To("my-app"),
+					}).App,
 					nil,
 				)
 				return m
@@ -294,7 +312,7 @@ func TestObserve(t *testing.T) {
 		},
 		"RouteFetchErrorNonFatal": {
 			args: args{
-				mg: newApp("docker", withExternalName(guid), withSpace(spaceGUID),
+				mg: newApp("docker", withExternalName(guid), withSpace(spaceGUID), withDefaultMetadataLabels(),
 					withRoutes(v1alpha1.AppRouteObservation{
 						URL:      "stale.apps.example.com",
 						Host:     "stale",
@@ -317,11 +335,17 @@ func TestObserve(t *testing.T) {
 			service: func() *fake.MockApp {
 				m := &fake.MockApp{}
 				m.On("Get", guid).Return(
-					&fake.NewApp("docker").SetName(name).SetGUID(guid).App,
+					&fake.NewApp("docker").SetName(name).SetGUID(guid).SetLabels(map[string]*string{
+						"crossplane-kind": ptr.To("app.cloudfoundry.crossplane.io"),
+						"crossplane-name": ptr.To("my-app"),
+					}).App,
 					nil,
 				)
 				m.On("Single").Return(
-					&fake.NewApp("docker").SetName(name).SetGUID(guid).App,
+					&fake.NewApp("docker").SetName(name).SetGUID(guid).SetLabels(map[string]*string{
+						"crossplane-kind": ptr.To("app.cloudfoundry.crossplane.io"),
+						"crossplane-name": ptr.To("my-app"),
+					}).App,
 					nil,
 				)
 				return m

--- a/internal/controller/domain/controller.go
+++ b/internal/controller/domain/controller.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
-	"k8s.io/utils/ptr"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	k8s "sigs.k8s.io/controller-runtime/pkg/client"
@@ -154,7 +153,7 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 
 	return managed.ExternalObservation{
 		ResourceExists:          cr.Status.AtProvider.ID != nil,
-		ResourceUpToDate:        domain.IsUpToDate(cr.Spec.ForProvider, d),
+		ResourceUpToDate:        domain.IsUpToDate(cr, cr.Spec.ForProvider, d),
 		ResourceLateInitialized: resourceLateInitialized,
 	}, nil
 }
@@ -168,7 +167,7 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 
 	cr.SetConditions(xpv1.Creating())
 
-	o, err := c.client.Create(ctx, domain.GenerateCreate(cr.Spec.ForProvider))
+	o, err := c.client.Create(ctx, domain.GenerateCreate(cr, cr.Spec.ForProvider))
 	if err != nil {
 		return managed.ExternalCreation{}, errors.Wrap(err, errCreate)
 	}
@@ -194,12 +193,9 @@ func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 		return managed.ExternalUpdate{}, errors.New(errUpdate)
 	}
 
-	// rename resource
-	if cr.Name != ptr.Deref(cr.Status.AtProvider.Name, "") {
-		_, err := c.client.Update(ctx, *cr.Status.AtProvider.ID, domain.GenerateUpdate(cr.Spec.ForProvider))
-		if err != nil {
-			return managed.ExternalUpdate{}, errors.Wrap(err, errUpdate)
-		}
+	_, err := c.client.Update(ctx, *cr.Status.AtProvider.ID, domain.GenerateUpdate(cr, cr.Spec.ForProvider))
+	if err != nil {
+		return managed.ExternalUpdate{}, errors.Wrap(err, errUpdate)
 	}
 
 	return managed.ExternalUpdate{

--- a/internal/controller/domain/controller_test.go
+++ b/internal/controller/domain/controller_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	"github.com/SAP/crossplane-provider-cloudfoundry/apis/resources/v1alpha1"
 	"github.com/SAP/crossplane-provider-cloudfoundry/internal/clients/fake"
@@ -65,6 +66,12 @@ func fakeDomain(m ...modifier) *v1alpha1.Domain {
 		rm(r)
 	}
 	return r
+}
+
+func withDefaultMetadataLabels() modifier {
+	return func(r *v1alpha1.Domain) {
+		r.SetGroupVersionKind(v1alpha1.Domain_GroupVersionKind)
+	}
 }
 
 func TestObserve(t *testing.T) {
@@ -174,6 +181,7 @@ func TestObserve(t *testing.T) {
 				mg: fakeDomain(
 					withExternalName(guid),
 					withName(name),
+					withDefaultMetadataLabels(),
 				),
 			},
 			want: want{
@@ -188,11 +196,11 @@ func TestObserve(t *testing.T) {
 				m := &fake.MockDomain{}
 
 				m.On("Get", guid).Return(
-					&fake.NewDomain().SetName(name).SetGUID(guid).Domain,
+					&fake.NewDomain().SetName(name).SetGUID(guid).SetLabels(map[string]*string{"crossplane-kind": ptr.To("domain.cloudfoundry.crossplane.io"), "crossplane-name": ptr.To("sap.my-domain.com")}).Domain,
 					nil,
 				)
 				m.On("Single").Return(
-					&fake.NewDomain().SetName(name).SetGUID(guid).Domain,
+					&fake.NewDomain().SetName(name).SetGUID(guid).SetLabels(map[string]*string{"crossplane-kind": ptr.To("domain.cloudfoundry.crossplane.io"), "crossplane-name": ptr.To("sap.my-domain.com")}).Domain,
 					nil,
 				)
 				return m
@@ -200,7 +208,7 @@ func TestObserve(t *testing.T) {
 		},
 		"Successful when guid is not provided and Domain with name is found ": {
 			args: args{
-				mg: fakeDomain(withName(name)),
+				mg: fakeDomain(withName(name), withDefaultMetadataLabels()),
 			},
 			want: want{
 				mg: fakeDomain(withName(name), withExternalName(guid)),
@@ -218,7 +226,7 @@ func TestObserve(t *testing.T) {
 					fake.ErrNoResultReturned,
 				)
 				m.On("Single").Return(
-					&fake.NewDomain().SetName(name).SetGUID(guid).Domain,
+					&fake.NewDomain().SetName(name).SetGUID(guid).SetLabels(map[string]*string{"crossplane-kind": ptr.To("domain.cloudfoundry.crossplane.io"), "crossplane-name": ptr.To("sap.my-domain.com")}).Domain,
 					nil,
 				)
 				return m
@@ -322,7 +330,7 @@ func TestCreate(t *testing.T) {
 					errBoom,
 				)
 				m.On("Single").Return(
-					&fake.NewDomain().SetName(name).SetGUID(guid).Domain,
+					&fake.NewDomain().SetName(name).SetGUID(guid).SetLabels(map[string]*string{"crossplane-kind": ptr.To("domain.cloudfoundry.crossplane.io"), "crossplane-name": ptr.To("sap.my-domain.com")}).Domain,
 					nil,
 				)
 				return m

--- a/internal/controller/org/controller.go
+++ b/internal/controller/org/controller.go
@@ -167,8 +167,8 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 	}
 
 	return managed.ExternalObservation{
-		ResourceExists:          true,
-		ResourceUpToDate:        org.IsUpToDate(cr.Spec.ForProvider, o),
+		ResourceExists:          cr.Status.AtProvider.ID != nil,
+		ResourceUpToDate:        org.IsUpToDate(cr, cr.Spec.ForProvider, o),
 		ResourceLateInitialized: resourceLateInitialized,
 	}, nil
 }
@@ -180,7 +180,7 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 		return managed.ExternalCreation{}, errors.New(errNotOrgKind)
 	}
 
-	o, err := c.client.Create(ctx, org.GenerateCreate(cr.Spec.ForProvider))
+	o, err := c.client.Create(ctx, org.GenerateCreate(cr, cr.Spec.ForProvider))
 	if err != nil {
 		return managed.ExternalCreation{}, errors.Wrap(err, errCreate)
 	}

--- a/internal/controller/org/controller_test.go
+++ b/internal/controller/org/controller_test.go
@@ -66,6 +66,12 @@ func fakeOrg(m ...modifier) *v1alpha1.Organization {
 	return r
 }
 
+func withDefaultMetadataLabels() modifier {
+	return func(r *v1alpha1.Organization) {
+		r.SetGroupVersionKind(v1alpha1.Org_GroupVersionKind)
+	}
+}
+
 func TestObserve(t *testing.T) {
 	type service func() *fake.MockOrganization
 	type args struct {
@@ -116,12 +122,109 @@ func TestObserve(t *testing.T) {
 				return m
 			},
 		},
-		"UnsetExternalNameSuccessful": {
+		"NotFound if org with guid is not found. Match by name should not be called": {
 			args: args{
-				mg: fakeOrg(withName(name)),
+				mg: fakeOrg(withExternalName(guid)),
 			},
 			want: want{
-				mg: fakeOrg(withName(name), withExternalName(guid)),
+				mg:  fakeOrg(withExternalName(guid)),
+				obs: managed.ExternalObservation{ResourceExists: false},
+				err: nil,
+			},
+			service: func() *fake.MockOrganization {
+				m := &fake.MockOrganization{}
+				m.On("Get", guid).Return(
+					fake.OrganizationNil,
+					fake.ErrNoResultReturned,
+				)
+				m.On("Single").Return( // this should not be called
+					&fake.NewOrganization().SetName(name).SetGUID(guid).Organization,
+					nil,
+				)
+				return m
+			},
+			kube: &test.MockClient{},
+		},
+		"NotFound by uuid is not provided and org with name is not found": {
+			args: args{
+				mg: fakeOrg(withName(name), withExternalName("not-a-uuid")),
+			},
+			want: want{
+				mg:  fakeOrg(withName(name), withExternalName("not-a-uuid")),
+				obs: managed.ExternalObservation{},
+				err: errors.New("external-name 'not-a-uuid' is not a valid GUID format"),
+			},
+			service: func() *fake.MockOrganization {
+				m := &fake.MockOrganization{}
+				// No mock calls needed: GUID validation fails before any API call
+				return m
+			},
+		},
+		"Successful when org with guid is found": {
+			args: args{
+				mg: fakeOrg(
+					withExternalName(guid),
+					withName(name),
+					withDefaultMetadataLabels(),
+				),
+			},
+			want: want{
+				mg: fakeOrg(
+					withExternalName(guid),
+					withName(name),
+				),
+				obs: managed.ExternalObservation{ResourceExists: true, ResourceUpToDate: true},
+				err: nil,
+			},
+			service: func() *fake.MockOrganization {
+				m := &fake.MockOrganization{}
+
+				m.On("Get", guid).Return(
+					&fake.NewOrganization().SetName(name).SetGUID(guid).SetLabels(map[string]*string{"crossplane-kind": ptr.To("organization.cloudfoundry.crossplane.io"), "crossplane-name": ptr.To("my-org")}).Organization,
+					nil,
+				)
+				m.On("Single").Return(
+					&fake.NewOrganization().SetName(name).SetGUID(guid).SetLabels(map[string]*string{"crossplane-kind": ptr.To("organization.cloudfoundry.crossplane.io"), "crossplane-name": ptr.To("my-org")}).Organization,
+					nil,
+				)
+				return m
+			},
+		},
+		"Successful when org with guid is found, even after rename": {
+			args: args{
+				mg: fakeOrg(
+					withExternalName(guid),
+					withName("not-my-org"),
+				),
+			},
+			want: want{
+				mg: fakeOrg(
+					withExternalName(guid),
+					withName("not-my-org"),
+				),
+				obs: managed.ExternalObservation{ResourceExists: true, ResourceUpToDate: false},
+				err: nil,
+			},
+			service: func() *fake.MockOrganization {
+				m := &fake.MockOrganization{}
+
+				m.On("Get", guid).Return(
+					&fake.NewOrganization().SetName(name).SetGUID(guid).Organization,
+					nil,
+				)
+				m.On("Single").Return(
+					&fake.NewOrganization().SetName(name).SetGUID(guid).Organization,
+					nil,
+				)
+				return m
+			},
+		},
+		"Successful when guid is not provided and org with name is found ": {
+			args: args{
+				mg: fakeOrg(withName(name), withDefaultMetadataLabels()),
+			},
+			want: want{
+				mg: fakeOrg(withName(name), withExternalName(guid), withDefaultMetadataLabels()),
 				obs: managed.ExternalObservation{
 					ResourceExists:          true,
 					ResourceUpToDate:        true,
@@ -138,7 +241,7 @@ func TestObserve(t *testing.T) {
 				).Once()
 				// GetOrgByGUID calls Get with the discovered GUID
 				m.On("Get", guid).Return(
-					&fake.NewOrganization().SetName(name).SetGUID(guid).Organization,
+					&fake.NewOrganization().SetName(name).SetGUID(guid).SetLabels(map[string]*string{"crossplane-kind": ptr.To("organization.cloudfoundry.crossplane.io"), "crossplane-name": ptr.To("my-org")}).Organization,
 					nil,
 				)
 				return m
@@ -184,7 +287,7 @@ func TestObserve(t *testing.T) {
 		},
 		"SetExternalNameSuccessful": {
 			args: args{
-				mg: fakeOrg(withExternalName(guid), withName(name)),
+				mg: fakeOrg(withExternalName(guid), withName(name), withDefaultMetadataLabels()),
 			},
 			want: want{
 				mg: fakeOrg(withExternalName(guid), withName(name)),
@@ -198,7 +301,7 @@ func TestObserve(t *testing.T) {
 				m := &fake.MockOrganization{}
 				// GetOrgByGUID calls Get with the GUID
 				m.On("Get", guid).Return(
-					&fake.NewOrganization().SetName(name).SetGUID(guid).Organization,
+					&fake.NewOrganization().SetName(name).SetGUID(guid).SetLabels(map[string]*string{"crossplane-kind": ptr.To("organization.cloudfoundry.crossplane.io"), "crossplane-name": ptr.To("my-org")}).Organization,
 					nil,
 				)
 				return m

--- a/internal/controller/route/controller.go
+++ b/internal/controller/route/controller.go
@@ -33,11 +33,9 @@ import (
 
 type RouteService interface {
 	FindRouteBySpec(ctx context.Context, forProvider v1alpha1.RouteParameters) (*v1alpha1.RouteObservation, bool, error)
-
 	GetRouteByGUID(ctx context.Context, guid string) (*v1alpha1.RouteObservation, bool, error)
-
-	Create(ctx context.Context, forProvider v1alpha1.RouteParameters) (string, error)
-	Update(ctx context.Context, guid string, forProvider v1alpha1.RouteParameters) error
+	Create(ctx context.Context, mg resource.Managed, forProvider v1alpha1.RouteParameters) (string, error)
+	Update(ctx context.Context, guid string, mg resource.Managed, forProvider v1alpha1.RouteParameters) error
 	Delete(ctx context.Context, guid string) (string, error)
 }
 
@@ -178,7 +176,7 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 
 	return managed.ExternalObservation{
 		ResourceExists:          true,
-		ResourceUpToDate:        route.IsUpToDate(cr.Spec.ForProvider, *observed),
+		ResourceUpToDate:        route.IsUpToDate(cr, cr.Spec.ForProvider, cr.Status.AtProvider),
 		ResourceLateInitialized: resourceLateInitialized,
 	}, nil
 }
@@ -192,7 +190,7 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 
 	cr.SetConditions(xpv1.Creating())
 
-	guid, err := c.RouteService.Create(ctx, cr.Spec.ForProvider)
+	guid, err := c.RouteService.Create(ctx, cr, cr.Spec.ForProvider)
 	if err != nil {
 		return managed.ExternalCreation{}, errors.Wrap(err, errCreate)
 	}
@@ -212,7 +210,7 @@ func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 	}
 
 	guid := meta.GetExternalName(cr)
-	err := c.RouteService.Update(ctx, guid, cr.Spec.ForProvider)
+	err := c.RouteService.Update(ctx, guid, cr, cr.Spec.ForProvider)
 	if err != nil {
 		return managed.ExternalUpdate{}, errors.Wrap(err, errUpdate)
 	}

--- a/internal/controller/route/controller_test.go
+++ b/internal/controller/route/controller_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	"github.com/SAP/crossplane-provider-cloudfoundry/apis/resources/v1alpha1"
 	"github.com/SAP/crossplane-provider-cloudfoundry/internal/clients/fake"
@@ -35,12 +36,12 @@ func (m *Mock) GetRouteByGUID(ctx context.Context, guid string) (*v1alpha1.Route
 	return args.Get(0).(*v1alpha1.RouteObservation), args.Bool(1), args.Error(2)
 }
 
-func (m *Mock) Create(ctx context.Context, forProvider v1alpha1.RouteParameters) (string, error) {
+func (m *Mock) Create(ctx context.Context, mg resource.Managed, forProvider v1alpha1.RouteParameters) (string, error) {
 	args := m.Called()
 	return args.String(0), args.Error(1)
 }
 
-func (m *Mock) Update(ctx context.Context, guid string, forProvider v1alpha1.RouteParameters) error {
+func (m *Mock) Update(ctx context.Context, guid string, mg resource.Managed, forProvider v1alpha1.RouteParameters) error {
 	args := m.Called()
 	return args.Error(0)
 }
@@ -111,8 +112,17 @@ func fakeRouteObservation(id string) *v1alpha1.RouteObservation {
 	}
 	r := &v1alpha1.RouteObservation{
 		Resource: res,
+		ResourceMetadata: v1alpha1.ResourceMetadata{
+			Labels: map[string]*string{"crossplane-kind": ptr.To("route.cloudfoundry.crossplane.io"), "crossplane-name": ptr.To("test-route")},
+		},
 	}
 	return r
+}
+
+func withDefaultMetadataLabels() modifier {
+	return func(r *v1alpha1.Route) {
+		r.SetGroupVersionKind(v1alpha1.RouteGroupVersionKind)
+	}
 }
 
 func TestObserve(t *testing.T) {
@@ -148,6 +158,45 @@ func TestObserve(t *testing.T) {
 		"UnsetExternalNameSuccessful": {
 			args: args{
 				mg: fakeRoute(withHost(name)),
+			},
+			want: want{
+				obs: managed.ExternalObservation{
+					ResourceExists: false,
+				},
+				err: nil,
+			},
+			service: func() *Mock {
+				m := &Mock{}
+				m.On("FindRouteBySpec", fakeRoute(withHost(name)).Spec.ForProvider).Return(
+					nilObservation, false, nil,
+				)
+				return m
+			},
+		},
+		"Found with observation is returned": {
+			args: args{
+				mg: fakeRoute(
+					withExternalName(guid),
+					withHost(name),
+					withDefaultMetadataLabels(),
+				),
+			},
+			want: want{
+				obs: managed.ExternalObservation{ResourceExists: true, ResourceUpToDate: true},
+				err: nil,
+			},
+			service: func() *Mock {
+				m := &Mock{}
+
+				m.On("GetRouteByGUID", guid).Return(
+					fakeRouteObservation(guid), true, nil,
+				)
+				return m
+			},
+		},
+		"Adopt and set external-name ": {
+			args: args{
+				mg: fakeRoute(withHost(name), withDefaultMetadataLabels()),
 			},
 			want: want{
 				obs: managed.ExternalObservation{
@@ -189,6 +238,7 @@ func TestObserve(t *testing.T) {
 				mg: fakeRoute(
 					withExternalName(guid),
 					withHost(name),
+					withDefaultMetadataLabels(),
 				),
 			},
 			want: want{

--- a/internal/controller/servicecredentialbinding/controller.go
+++ b/internal/controller/servicecredentialbinding/controller.go
@@ -202,7 +202,7 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 		return managed.ExternalCreation{}, fmt.Errorf(errExtractParams, err)
 	}
 
-	serviceBinding, err := scb.Create(ctx, c.scbClient, cr.Spec.ForProvider, params)
+	serviceBinding, err := scb.Create(ctx, c.scbClient, cr, cr.Spec.ForProvider, params)
 	if err != nil {
 		return managed.ExternalCreation{}, fmt.Errorf(errCreate, err)
 	}
@@ -226,7 +226,7 @@ func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 	}
 
 	if externalName := meta.GetExternalName(cr); externalName != "" {
-		if _, err := scb.Update(ctx, c.scbClient, meta.GetExternalName(cr), cr.Spec.ForProvider); err != nil {
+		if _, err := scb.Update(ctx, c.scbClient, meta.GetExternalName(cr), cr, cr.Spec.ForProvider); err != nil {
 			return managed.ExternalUpdate{}, fmt.Errorf(errUpdate, err)
 		}
 	}
@@ -305,7 +305,7 @@ func (c *external) HandleObservationState(serviceBinding *cfresource.ServiceCred
 
 		return managed.ExternalObservation{
 			ResourceExists:    true,
-			ResourceUpToDate:  scb.IsUpToDate(ctx, cr.Spec.ForProvider, *serviceBinding) && !c.keyRotator.HasExpiredKeys(cr),
+			ResourceUpToDate:  scb.IsUpToDate(ctx, cr, cr.Spec.ForProvider, *serviceBinding) && !c.keyRotator.HasExpiredKeys(cr),
 			ConnectionDetails: scb.GetConnectionDetails(ctx, c.scbClient, serviceBinding.GUID, cr.Spec.ConnectionDetailsAsJSON),
 		}, nil
 	}

--- a/internal/controller/servicecredentialbinding/controller_test.go
+++ b/internal/controller/servicecredentialbinding/controller_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	"github.com/SAP/crossplane-provider-cloudfoundry/apis/resources/v1alpha1"
 	"github.com/SAP/crossplane-provider-cloudfoundry/internal/clients/fake"
@@ -91,6 +92,12 @@ func serviceCredentialBinding(typ string, m ...modifier) *v1alpha1.ServiceCreden
 	}
 	return r
 }
+func withDefaultMetadataLabels() modifier {
+	return func(r *v1alpha1.ServiceCredentialBinding) {
+		r.SetGroupVersionKind(v1alpha1.ServiceCredentialBindingGroupVersionKind)
+	}
+}
+
 func TestObserve(t *testing.T) {
 	type service func() *fake.MockServiceCredentialBinding
 	type keyRotator func() *fake.MockKeyRotator
@@ -105,17 +112,18 @@ func TestObserve(t *testing.T) {
 		err error
 	}
 
-	scb := serviceCredentialBinding("key", withExternalName(guid), withServiceInstanceID(serviceInstanceGUID))
+	scb := serviceCredentialBinding("key", withExternalName(guid), withServiceInstanceID(serviceInstanceGUID), withDefaultMetadataLabels())
 	scbAvailable := serviceCredentialBinding(
 		"key",
 		withExternalName(guid),
 		withStatus(guid),
 		withServiceInstanceID(serviceInstanceGUID),
 		withConditions(xpv1.Available()),
+		withDefaultMetadataLabels(),
 	)
 
 	cfSucceeded := func() *cfresource.ServiceCredentialBinding {
-		return &fake.NewServiceCredentialBinding("key").SetName(name).SetGUID(guid).SetServiceInstanceRef(serviceInstanceGUID).SetLastOperation(v1alpha1.LastOperationCreate, v1alpha1.LastOperationSucceeded).ServiceCredentialBinding
+		return &fake.NewServiceCredentialBinding("key").SetName(name).SetGUID(guid).SetServiceInstanceRef(serviceInstanceGUID).SetLastOperation(v1alpha1.LastOperationCreate, v1alpha1.LastOperationSucceeded).SetLabels(map[string]*string{"crossplane-kind": ptr.To("servicecredentialbinding.cloudfoundry.crossplane.io"), "crossplane-name": ptr.To("my-service-credential-binding")}).ServiceCredentialBinding
 	}
 
 	cases := map[string]struct {
@@ -597,10 +605,10 @@ func TestHandleObservationState(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	cr := serviceCredentialBinding("key", withExternalName(guid), withServiceInstanceID(serviceInstanceGUID))
+	cr := serviceCredentialBinding("key", withExternalName(guid), withServiceInstanceID(serviceInstanceGUID), withDefaultMetadataLabels())
 
 	scbCreate := func(lastOperation string) *cfresource.ServiceCredentialBinding {
-		return &fake.NewServiceCredentialBinding("key").SetName(name).SetGUID(guid).SetServiceInstanceRef(serviceInstanceGUID).SetLastOperation(v1alpha1.LastOperationCreate, lastOperation).ServiceCredentialBinding
+		return &fake.NewServiceCredentialBinding("key").SetName(name).SetGUID(guid).SetServiceInstanceRef(serviceInstanceGUID).SetLastOperation(v1alpha1.LastOperationCreate, lastOperation).SetLabels(map[string]*string{"crossplane-kind": ptr.To("servicecredentialbinding.cloudfoundry.crossplane.io"), "crossplane-name": ptr.To("my-service-credential-binding")}).ServiceCredentialBinding
 	}
 
 	cases := map[string]struct {

--- a/internal/controller/serviceinstance/controller.go
+++ b/internal/controller/serviceinstance/controller.go
@@ -211,7 +211,7 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 			credentialsUpToDate = bytes.Equal(desiredHash, cr.Status.AtProvider.Credentials)
 		}
 		// Check if the credentials in the spec match the credentials in the external resource
-		upToDate := credentialsUpToDate && serviceinstance.IsUpToDate(&cr.Spec.ForProvider, r)
+		upToDate := credentialsUpToDate && serviceinstance.IsUpToDate(cr, &cr.Spec.ForProvider, r)
 
 		// Check if shared spaces are up to date
 		sharedSpacesUpToDate, err := c.serviceinstance.AreSharedSpacesUpToDate(ctx, r.GUID, cr.Spec.ForProvider.SharedSpaces)
@@ -252,7 +252,7 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 		return managed.ExternalCreation{}, errors.Wrap(err, errSecret)
 	}
 
-	r, err := c.serviceinstance.Create(ctx, cr.Spec.ForProvider, creds)
+	r, err := c.serviceinstance.Create(ctx, cr, cr.Spec.ForProvider, creds)
 	if err != nil {
 		return managed.ExternalCreation{}, errors.Wrap(err, errCreate)
 	}
@@ -304,7 +304,7 @@ func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 		return managed.ExternalUpdate{}, errors.Wrap(err, errSecret)
 	}
 
-	if _, err := c.serviceinstance.Update(ctx, *cr.Status.AtProvider.ID, &cr.Spec.ForProvider, creds); err != nil {
+	if _, err := c.serviceinstance.Update(ctx, *cr.Status.AtProvider.ID, cr, &cr.Spec.ForProvider, creds); err != nil {
 		return managed.ExternalUpdate{}, errors.Wrap(err, errUpdate)
 	}
 

--- a/internal/controller/serviceinstance/controller_test.go
+++ b/internal/controller/serviceinstance/controller_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	"github.com/SAP/crossplane-provider-cloudfoundry/apis/resources/v1alpha1"
 	"github.com/SAP/crossplane-provider-cloudfoundry/internal/clients/fake"
@@ -129,6 +130,12 @@ func serviceInstance(typ string, m ...modifier) *v1alpha1.ServiceInstance {
 		rm(r)
 	}
 	return r
+}
+
+func withDefaultMetadataLabels() modifier {
+	return func(r *v1alpha1.ServiceInstance) {
+		r.SetGroupVersionKind(v1alpha1.ServiceInstance_GroupVersionKind)
+	}
 }
 
 func TestObserve(t *testing.T) {
@@ -253,7 +260,7 @@ func TestObserve(t *testing.T) {
 		},
 		"Successful - Get by GUID": {
 			args: args{
-				mg: serviceInstance("managed", withExternalName(guid), withSpace(spaceGUID), withServicePlan(v1alpha1.ServicePlanParameters{ID: &servicePlan})),
+				mg: serviceInstance("managed", withExternalName(guid), withSpace(spaceGUID), withServicePlan(v1alpha1.ServicePlanParameters{ID: &servicePlan}), withDefaultMetadataLabels()),
 			},
 			want: want{
 				mg: serviceInstance("managed",
@@ -261,6 +268,7 @@ func TestObserve(t *testing.T) {
 					withServicePlan(v1alpha1.ServicePlanParameters{ID: &servicePlan}),
 					withStatus(v1alpha1.ServiceInstanceObservation{ID: &guid, ServicePlan: &servicePlan}),
 					withConditions(xpv1.Available()),
+					withDefaultMetadataLabels(),
 				),
 				obs: managed.ExternalObservation{ResourceExists: true, ResourceUpToDate: true},
 				err: nil,
@@ -268,7 +276,7 @@ func TestObserve(t *testing.T) {
 			service: func() *fake.MockServiceInstance {
 				m := &fake.MockServiceInstance{}
 				m.On("Get", guid).Return(
-					&fake.NewServiceInstance("managed").SetName(name).SetGUID(guid).SetServicePlan(servicePlan).SetLastOperation(v1alpha1.LastOperationCreate, v1alpha1.LastOperationSucceeded).ServiceInstance,
+					&fake.NewServiceInstance("managed").SetName(name).SetGUID(guid).SetServicePlan(servicePlan).SetLastOperation(v1alpha1.LastOperationCreate, v1alpha1.LastOperationSucceeded).SetLabels(map[string]*string{"crossplane-kind": ptr.To("serviceinstance.cloudfoundry.crossplane.io"), "crossplane-name": ptr.To("my-service-instance")}).ServiceInstance,
 					nil,
 				)
 				m.On("Single").Return(
@@ -288,7 +296,7 @@ func TestObserve(t *testing.T) {
 		},
 		"Successful - adopt by forProvider spec": {
 			args: args{
-				mg: serviceInstance("managed", withExternalName("not-guid"), withSpace(spaceGUID), withServicePlan(v1alpha1.ServicePlanParameters{ID: &servicePlan})),
+				mg: serviceInstance("managed", withExternalName("not-guid"), withSpace(spaceGUID), withServicePlan(v1alpha1.ServicePlanParameters{ID: &servicePlan}), withDefaultMetadataLabels()),
 			},
 			want: want{
 				mg: serviceInstance("managed",
@@ -296,6 +304,7 @@ func TestObserve(t *testing.T) {
 					withServicePlan(v1alpha1.ServicePlanParameters{ID: &servicePlan}),
 					withStatus(v1alpha1.ServiceInstanceObservation{ID: &guid, ServicePlan: &servicePlan}),
 					withConditions(xpv1.Available()),
+					withDefaultMetadataLabels(),
 				),
 				obs: managed.ExternalObservation{ResourceExists: true, ResourceUpToDate: true},
 				err: nil,
@@ -307,7 +316,7 @@ func TestObserve(t *testing.T) {
 					fake.ErrNoResultReturned,
 				)
 				m.On("Single").Return(
-					&fake.NewServiceInstance("managed").SetName(name).SetGUID(guid).SetServicePlan(servicePlan).SetLastOperation(v1alpha1.LastOperationCreate, v1alpha1.LastOperationSucceeded).ServiceInstance,
+					&fake.NewServiceInstance("managed").SetName(name).SetGUID(guid).SetServicePlan(servicePlan).SetLastOperation(v1alpha1.LastOperationCreate, v1alpha1.LastOperationSucceeded).SetLabels(map[string]*string{"crossplane-kind": ptr.To("serviceinstance.cloudfoundry.crossplane.io"), "crossplane-name": ptr.To("my-service-instance")}).ServiceInstance,
 					nil,
 				)
 				m.On("GetManagedParameters", guid).Return(
@@ -493,7 +502,7 @@ func TestObserve(t *testing.T) {
 		},
 		"DriftDetectionBreak": {
 			args: args{
-				mg: serviceInstance("managed", withExternalName(guid), withSpace(spaceGUID), withServicePlan(v1alpha1.ServicePlanParameters{ID: &servicePlan}), withParameters("{\"foo\":\"bar\", \"baz\": 1}"), withDriftDetection(false), withStatus(v1alpha1.ServiceInstanceObservation{Credentials: iSha256([]byte("{\"foo\":\"bar\", \"baz\": 1}"))})),
+				mg: serviceInstance("managed", withExternalName(guid), withSpace(spaceGUID), withServicePlan(v1alpha1.ServicePlanParameters{ID: &servicePlan}), withParameters("{\"foo\":\"bar\", \"baz\": 1}"), withDriftDetection(false), withStatus(v1alpha1.ServiceInstanceObservation{Credentials: iSha256([]byte("{\"foo\":\"bar\", \"baz\": 1}"))}), withDefaultMetadataLabels()),
 			},
 			want: want{
 				mg: serviceInstance("managed",
@@ -503,6 +512,7 @@ func TestObserve(t *testing.T) {
 					withConditions(xpv1.Available()),
 					withParameters("{\"foo\":\"bar\", \"baz\": 1}"),
 					withDriftDetection(false),
+					withDefaultMetadataLabels(),
 				),
 				obs: managed.ExternalObservation{ResourceExists: true, ResourceUpToDate: true},
 				err: nil,
@@ -510,7 +520,7 @@ func TestObserve(t *testing.T) {
 			service: func() *fake.MockServiceInstance {
 				m := &fake.MockServiceInstance{}
 				m.On("Get", guid).Return(
-					&fake.NewServiceInstance("managed").SetName(name).SetGUID(guid).SetServicePlan(servicePlan).SetLastOperation(v1alpha1.LastOperationCreate, v1alpha1.LastOperationSucceeded).ServiceInstance,
+					&fake.NewServiceInstance("managed").SetName(name).SetGUID(guid).SetServicePlan(servicePlan).SetLastOperation(v1alpha1.LastOperationCreate, v1alpha1.LastOperationSucceeded).SetLabels(map[string]*string{"crossplane-kind": ptr.To("serviceinstance.cloudfoundry.crossplane.io"), "crossplane-name": ptr.To("my-service-instance")}).ServiceInstance,
 					nil,
 				)
 				m.On("Single").Return(
@@ -530,7 +540,7 @@ func TestObserve(t *testing.T) {
 		},
 		"UserProvidedService_EmptyLastOperation": {
 			args: args{
-				mg: serviceInstance("user-provided", withExternalName(guid), withSpace(spaceGUID), withCredentials(&jsonCredentials), withStatus(v1alpha1.ServiceInstanceObservation{Credentials: iSha256([]byte(jsonCredentials))})),
+				mg: serviceInstance("user-provided", withExternalName(guid), withSpace(spaceGUID), withCredentials(&jsonCredentials), withStatus(v1alpha1.ServiceInstanceObservation{Credentials: iSha256([]byte(jsonCredentials))}), withDefaultMetadataLabels()),
 			},
 			want: want{
 				mg: serviceInstance("user-provided",
@@ -539,6 +549,7 @@ func TestObserve(t *testing.T) {
 					withCredentials(&jsonCredentials),
 					withStatus(v1alpha1.ServiceInstanceObservation{ID: &guid, Credentials: iSha256([]byte(jsonCredentials))}),
 					withConditions(xpv1.Available()),
+					withDefaultMetadataLabels(),
 				),
 				obs: managed.ExternalObservation{ResourceExists: true, ResourceUpToDate: true},
 				err: nil,
@@ -547,7 +558,7 @@ func TestObserve(t *testing.T) {
 				m := &fake.MockServiceInstance{}
 				// User-provided services have empty LastOperation
 				m.On("Get", guid).Return(
-					&fake.NewServiceInstance("user-provided").SetName(name).SetGUID(guid).SetLastOperation("", "").ServiceInstance,
+					&fake.NewServiceInstance("user-provided").SetName(name).SetGUID(guid).SetLastOperation("", "").SetLabels(map[string]*string{"crossplane-kind": ptr.To("serviceinstance.cloudfoundry.crossplane.io"), "crossplane-name": ptr.To("my-service-instance")}).ServiceInstance,
 					nil,
 				)
 				m.On("Single").Return(
@@ -572,6 +583,7 @@ func TestObserve(t *testing.T) {
 					withSpace(spaceGUID),
 					withServicePlan(v1alpha1.ServicePlanParameters{ID: &servicePlan}),
 					withSharedSpaces(sharedSpaceGUID),
+					withDefaultMetadataLabels(),
 				),
 			},
 			want: want{
@@ -581,6 +593,7 @@ func TestObserve(t *testing.T) {
 					withSharedSpaces(sharedSpaceGUID),
 					withStatus(v1alpha1.ServiceInstanceObservation{ID: &guid, ServicePlan: &servicePlan}),
 					withConditions(xpv1.Available()),
+					withDefaultMetadataLabels(),
 				),
 				obs: managed.ExternalObservation{ResourceExists: true, ResourceUpToDate: true},
 				err: nil,
@@ -588,7 +601,7 @@ func TestObserve(t *testing.T) {
 			service: func() *fake.MockServiceInstance {
 				m := &fake.MockServiceInstance{}
 				m.On("Get", guid).Return(
-					&fake.NewServiceInstance("managed").SetName(name).SetGUID(guid).SetServicePlan(servicePlan).SetLastOperation(v1alpha1.LastOperationCreate, v1alpha1.LastOperationSucceeded).ServiceInstance,
+					&fake.NewServiceInstance("managed").SetName(name).SetGUID(guid).SetServicePlan(servicePlan).SetLastOperation(v1alpha1.LastOperationCreate, v1alpha1.LastOperationSucceeded).SetLabels(map[string]*string{"crossplane-kind": ptr.To("serviceinstance.cloudfoundry.crossplane.io"), "crossplane-name": ptr.To("my-service-instance")}).ServiceInstance,
 					nil,
 				)
 				m.On("GetManagedParameters", guid).Return(

--- a/internal/controller/serviceroutebinding/controller.go
+++ b/internal/controller/serviceroutebinding/controller.go
@@ -243,7 +243,7 @@ func (e *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 	}
 
 	// Update metadata (labels and annotations) - only supported fields for ServiceRouteBindings
-	_, err := srb.Update(ctx, e.srbClient, guid, cr.Spec.ForProvider)
+	_, err := srb.Update(ctx, e.srbClient, guid, cr, cr.Spec.ForProvider)
 	if err != nil {
 		return managed.ExternalUpdate{}, fmt.Errorf(errUpdate, err)
 	}
@@ -312,7 +312,8 @@ func handleObservationState(binding *cfresource.ServiceRouteBinding, cr *v1alpha
 			actualLabels = binding.Metadata.Labels
 			actualAnnotations = binding.Metadata.Annotations
 		}
-		upToDate := metadata.IsMetadataUpToDate(cr.Spec.ForProvider.Labels, cr.Spec.ForProvider.Annotations, actualLabels, actualAnnotations)
+		desired := metadata.BuildMetadata(cr, cr.Spec.ForProvider.Labels, cr.Spec.ForProvider.Annotations)
+		upToDate := metadata.IsMetadataUpToDate(desired.Labels, desired.Annotations, actualLabels, actualAnnotations)
 
 		return managed.ExternalObservation{ResourceExists: true, ResourceUpToDate: upToDate}, nil
 	}

--- a/internal/controller/serviceroutebinding/controller_test.go
+++ b/internal/controller/serviceroutebinding/controller_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	"github.com/SAP/crossplane-provider-cloudfoundry/apis/resources/v1alpha1"
 	"github.com/SAP/crossplane-provider-cloudfoundry/internal/clients"
@@ -109,6 +110,12 @@ func serviceRouteBinding(m ...modifier) *v1alpha1.ServiceRouteBinding {
 	return r
 }
 
+func withDefaultMetadataLabels() modifier {
+	return func(r *v1alpha1.ServiceRouteBinding) {
+		r.SetGroupVersionKind(v1alpha1.ServiceRouteBinding_GroupVersionKind)
+	}
+}
+
 func TestObserve(t *testing.T) {
 	type service func() *fake.MockServiceRouteBinding
 	type args struct {
@@ -125,6 +132,7 @@ func TestObserve(t *testing.T) {
 		withExternalName(guid),
 		withRouteID(routeGUID),
 		withServiceInstanceID(serviceInstanceGUID),
+		withDefaultMetadataLabels(),
 	)
 
 	srbAvailable := serviceRouteBinding(
@@ -133,6 +141,7 @@ func TestObserve(t *testing.T) {
 		withRouteID(routeGUID),
 		withServiceInstanceID(serviceInstanceGUID),
 		withConditions(xpv1.Available(), xpv1.ReconcileSuccess()),
+		withDefaultMetadataLabels(),
 	)
 
 	srbInvalid := serviceRouteBinding(
@@ -155,6 +164,7 @@ func TestObserve(t *testing.T) {
 			SetServiceInstanceRef(serviceInstanceGUID).
 			SetRouteServiceURL(routeServiceURL).
 			SetLastOperation(v1alpha1.LastOperationCreate, v1alpha1.LastOperationSucceeded).
+			SetLabels(map[string]*string{"crossplane-kind": ptr.To("serviceroutebinding.cloudfoundry.crossplane.io"), "crossplane-name": ptr.To("my-service-route-binding")}).
 			ServiceRouteBinding
 	}
 
@@ -209,6 +219,7 @@ func TestObserve(t *testing.T) {
 				mg: serviceRouteBinding(withExternalName(guid),
 					withRouteID(routeGUID),
 					withServiceInstanceID(serviceInstanceGUID),
+					withDefaultMetadataLabels(),
 				),
 				obs: managed.ExternalObservation{},
 				err: fmt.Errorf(errGet, errBoom),
@@ -234,6 +245,7 @@ func TestObserve(t *testing.T) {
 				mg: serviceRouteBinding(withExternalName(guid),
 					withRouteID(routeGUID),
 					withServiceInstanceID(serviceInstanceGUID),
+					withDefaultMetadataLabels(),
 				),
 				obs: managed.ExternalObservation{ResourceExists: false},
 				err: nil,
@@ -285,6 +297,7 @@ func TestObserve(t *testing.T) {
 					withRouteID(routeGUID),
 					withServiceInstanceID(serviceInstanceGUID),
 					withConditions(xpv1.Unavailable().WithMessage("create in progress")),
+					withDefaultMetadataLabels(),
 				),
 				obs: managed.ExternalObservation{ResourceExists: true, ResourceUpToDate: true},
 				err: nil,
@@ -315,6 +328,7 @@ func TestObserve(t *testing.T) {
 					withRouteID(routeGUID),
 					withServiceInstanceID(serviceInstanceGUID),
 					withConditions(xpv1.Unavailable().WithMessage("create failed")),
+					withDefaultMetadataLabels(),
 				),
 				obs: managed.ExternalObservation{ResourceExists: false, ResourceUpToDate: true},
 				err: nil,
@@ -872,8 +886,9 @@ func TestHandleObservationState(t *testing.T) {
 			args: args{
 				binding: &fake.NewServiceRouteBinding().
 					SetLastOperation(v1alpha1.LastOperationCreate, v1alpha1.LastOperationSucceeded).
+					SetLabels(map[string]*string{"crossplane-kind": ptr.To("serviceroutebinding.cloudfoundry.crossplane.io"), "crossplane-name": ptr.To("my-service-route-binding")}).
 					ServiceRouteBinding,
-				cr: serviceRouteBinding(),
+				cr: serviceRouteBinding(withDefaultMetadataLabels()),
 			},
 			want: want{
 				obs: managed.ExternalObservation{ResourceExists: true, ResourceUpToDate: true},

--- a/internal/controller/space/controller.go
+++ b/internal/controller/space/controller.go
@@ -178,7 +178,7 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 
 	return managed.ExternalObservation{
 		ResourceExists:          true,
-		ResourceUpToDate:        space.IsUpToDate(cr.Spec.ForProvider, s, ssh),
+		ResourceUpToDate:        space.IsUpToDate(cr, cr.Spec.ForProvider, s, ssh),
 		ResourceLateInitialized: resourceLateInitialized,
 	}, nil
 }
@@ -192,7 +192,7 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 
 	cr.SetConditions(xpv1.Creating())
 
-	s, err := c.client.Create(ctx, space.GenerateCreate(cr.Spec.ForProvider))
+	s, err := c.client.Create(ctx, space.GenerateCreate(cr, cr.Spec.ForProvider))
 	if err != nil {
 		return managed.ExternalCreation{}, errors.Wrap(err, errCreate)
 	}
@@ -240,12 +240,9 @@ func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 		}
 	}
 
-	// rename
-	if cr.Spec.ForProvider.Name != cr.Status.AtProvider.Name {
-		_, err := c.client.Update(ctx, guid, space.GenerateUpdate(cr.Spec.ForProvider))
-		if err != nil {
-			return managed.ExternalUpdate{}, errors.Wrap(err, errUpdate)
-		}
+	_, err := c.client.Update(ctx, guid, space.GenerateUpdate(cr, cr.Spec.ForProvider))
+	if err != nil {
+		return managed.ExternalUpdate{}, errors.Wrap(err, errUpdate)
 	}
 
 	return managed.ExternalUpdate{}, nil

--- a/internal/controller/space/controller_test.go
+++ b/internal/controller/space/controller_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	"github.com/SAP/crossplane-provider-cloudfoundry/apis/resources/v1alpha1"
 	"github.com/SAP/crossplane-provider-cloudfoundry/internal/clients/fake"
@@ -80,6 +81,12 @@ func fakeSpace(m ...modifier) *v1alpha1.Space {
 type MockSpaceFeature struct {
 	*fake.MockSpace
 	*fake.MockFeature
+}
+
+func withDefaultMetadataLabels() modifier {
+	return func(r *v1alpha1.Space) {
+		r.SetGroupVersionKind(v1alpha1.Space_GroupVersionKind)
+	}
 }
 
 func TestObserve(t *testing.T) {
@@ -178,10 +185,10 @@ func TestObserve(t *testing.T) {
 		},
 		"UnsetExternalNameSuccessful": {
 			args: args{
-				mg: fakeSpace(withName(name), withOrg(orgGuid)),
+				mg: fakeSpace(withName(name), withOrg(orgGuid), withDefaultMetadataLabels()),
 			},
 			want: want{
-				mg:  fakeSpace(withName(name), withOrg(orgGuid), withExternalName(guid), withAllowSSH(false), withConditions(xpv1.Available())),
+				mg:  fakeSpace(withName(name), withOrg(orgGuid), withExternalName(guid), withAllowSSH(false), withConditions(xpv1.Available()), withDefaultMetadataLabels()),
 				obs: managed.ExternalObservation{ResourceExists: true, ResourceUpToDate: true, ResourceLateInitialized: true},
 				err: nil,
 			},
@@ -190,12 +197,12 @@ func TestObserve(t *testing.T) {
 				f := &fake.MockFeature{}
 
 				m.On("Single").Return(
-					&fake.NewSpace().SetName(name).SetGUID(guid).SetRelationships(orgGuid).Space,
+					&fake.NewSpace().SetName(name).SetGUID(guid).SetRelationships(orgGuid).SetLabels(map[string]*string{"crossplane-kind": ptr.To("space.cloudfoundry.crossplane.io"), "crossplane-name": ptr.To("my-space")}).Space,
 					nil,
 				)
 
 				m.On("Get", guid).Return(
-					&fake.NewSpace().SetName(name).SetGUID(guid).SetRelationships(orgGuid).Space,
+					&fake.NewSpace().SetName(name).SetGUID(guid).SetRelationships(orgGuid).SetLabels(map[string]*string{"crossplane-kind": ptr.To("space.cloudfoundry.crossplane.io"), "crossplane-name": ptr.To("my-space")}).Space,
 					nil,
 				)
 
@@ -232,10 +239,10 @@ func TestObserve(t *testing.T) {
 		},
 		"SetExternalNameSuccessful": {
 			args: args{
-				mg: fakeSpace(withName(name), withOrg(orgGuid), withExternalName(guid)),
+				mg: fakeSpace(withName(name), withOrg(orgGuid), withExternalName(guid), withDefaultMetadataLabels()),
 			},
 			want: want{
-				mg:  fakeSpace(withName(name), withOrg(orgGuid), withAllowSSH(false), withExternalName(guid), withConditions(xpv1.Available())),
+				mg:  fakeSpace(withName(name), withOrg(orgGuid), withAllowSSH(false), withExternalName(guid), withConditions(xpv1.Available()), withDefaultMetadataLabels()),
 				obs: managed.ExternalObservation{ResourceExists: true, ResourceUpToDate: true, ResourceLateInitialized: false},
 				err: nil,
 			},
@@ -244,7 +251,7 @@ func TestObserve(t *testing.T) {
 				f := &fake.MockFeature{}
 
 				m.On("Get", guid).Return(
-					&fake.NewSpace().SetName(name).SetGUID(guid).SetRelationships(orgGuid).Space,
+					&fake.NewSpace().SetName(name).SetGUID(guid).SetRelationships(orgGuid).SetLabels(map[string]*string{"crossplane-kind": ptr.To("space.cloudfoundry.crossplane.io"), "crossplane-name": ptr.To("my-space")}).Space,
 					nil,
 				)
 
@@ -261,7 +268,7 @@ func TestObserve(t *testing.T) {
 			},
 			want: want{
 				mg:  fakeSpace(withName("existing-space"), withExternalName(guid), withAllowSSH(false), withOrg(orgGuid), withConditions(xpv1.Available())),
-				obs: managed.ExternalObservation{ResourceExists: true, ResourceUpToDate: true, ResourceLateInitialized: false},
+				obs: managed.ExternalObservation{ResourceExists: true, ResourceUpToDate: false, ResourceLateInitialized: false},
 				err: nil,
 			},
 			service: func() *MockSpaceFeature {


### PR DESCRIPTION
## What
- All 7 eligible resource Create/Update functions now call `BuildMetadata`, ensuring default Crossplane labels (`crossplane-kind`, `crossplane-name`, `crossplane-providerconfig`) and user-provided labels/annotations are included in CF API calls
- All `IsUpToDate` functions now detect metadata drift using subset semantics
- Observation functions read back labels/annotations from CF (closing the metadata loop)
- Org gets `LateInitialize` for metadata (with `StripDefaultLabels` to avoid circular updates)
- Remove stale Domain/Space update guards
- Add `SetLabels`/`SetAnnotations` fake builders for testing
- Add `metadata.StripDefaultLabels` helper

## Why
Core delivery of #39. Every CF resource now gets `crossplane-kind`, `crossplane-name`, `crossplane-providerconfig` labels automatically and tracks user-defined metadata.

## Part of
Split from #281 — PR 3 of 6 (core feature). Depends on [281#1] + [281#2].

**Merge order:** [281#1] → [281#2] → [281#3] → [281#4] → [281#5] → [281#6]