### PR TITLE
[281#4] fix(exporter): strip Crossplane default labels from exported CF resources

### DIFF
--- a/cmd/exporter/cf/app/convert.go
+++ b/cmd/exporter/cf/app/convert.go
@@ -7,9 +7,9 @@ import (
 	"log/slog"
 
 	"github.com/SAP/crossplane-provider-cloudfoundry/apis/resources/v1alpha1"
+	"github.com/SAP/crossplane-provider-cloudfoundry/cmd/exporter/cf/metadata"
 	"github.com/SAP/crossplane-provider-cloudfoundry/cmd/exporter/cf/space"
 
-	"github.com/SAP/crossplane-provider-cloudfoundry/cmd/exporter/cf/metadata"
 	"github.com/SAP/xp-clifford/cli/export"
 	"github.com/SAP/xp-clifford/erratt"
 	"github.com/SAP/xp-clifford/parsan"

--- a/cmd/exporter/cf/app/convert.go
+++ b/cmd/exporter/cf/app/convert.go
@@ -9,6 +9,7 @@ import (
 	"github.com/SAP/crossplane-provider-cloudfoundry/apis/resources/v1alpha1"
 	"github.com/SAP/crossplane-provider-cloudfoundry/cmd/exporter/cf/space"
 
+	"github.com/SAP/crossplane-provider-cloudfoundry/cmd/exporter/cf/metadata"
 	"github.com/SAP/xp-clifford/cli/export"
 	"github.com/SAP/xp-clifford/erratt"
 	"github.com/SAP/xp-clifford/parsan"
@@ -154,6 +155,10 @@ func convertAppResource(ctx context.Context, cfClient *client.Client, app *res, 
 				Lifecycle: app.Lifecycle.Type,
 				SpaceReference: v1alpha1.SpaceReference{
 					Space: &app.Relationships.Space.Data.GUID,
+				},
+				ResourceMetadata: v1alpha1.ResourceMetadata{
+					Labels:      metadata.StripDefaultLabels(app.Metadata.Labels),
+					Annotations: app.Metadata.Annotations,
 				},
 				// Buildpacks:                        []string{}, // not supported yet
 				// Stack:                             new(string), // not supported yet

--- a/cmd/exporter/cf/metadata/metadata.go
+++ b/cmd/exporter/cf/metadata/metadata.go
@@ -1,0 +1,31 @@
+// Package metadata provides shared helpers for the CF exporter.
+package metadata
+
+import (
+	"github.com/crossplane/crossplane-runtime/pkg/resource"
+)
+
+// StripDefaultLabels removes Crossplane default label keys from a label map.
+// The default labels (crossplane-kind, crossplane-name, crossplane-providerconfig)
+// are infrastructure metadata computed by the controller from the CR identity.
+// They should not be included in exported ForProvider labels because they are
+// semantically incorrect for a new CR (different name, different ProviderConfig)
+// and the controller will recompute them on the next reconcile.
+func StripDefaultLabels(labels map[string]*string) map[string]*string {
+	if labels == nil {
+		return nil
+	}
+	result := make(map[string]*string, len(labels))
+	for k, v := range labels {
+		if k == resource.ExternalResourceTagKeyKind ||
+			k == resource.ExternalResourceTagKeyName ||
+			k == resource.ExternalResourceTagKeyProvider {
+			continue
+		}
+		result[k] = v
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}

--- a/cmd/exporter/cf/org/convert.go
+++ b/cmd/exporter/cf/org/convert.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/SAP/crossplane-provider-cloudfoundry/apis/resources/v1alpha1"
 
+	"github.com/SAP/crossplane-provider-cloudfoundry/cmd/exporter/cf/metadata"
 	"github.com/SAP/xp-clifford/yaml"
 	v1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,7 +34,7 @@ func convertOrgResource(org *res) *yaml.ResourceWithComment {
 				ForProvider: v1alpha1.OrgParameters{
 					ResourceMetadata: v1alpha1.ResourceMetadata{
 						Annotations: org.Metadata.Annotations,
-						Labels:      org.Metadata.Labels,
+						Labels:      metadata.StripDefaultLabels(org.Metadata.Labels),
 					},
 					Name:      org.Name,
 					Suspended: &org.Suspended,

--- a/cmd/exporter/cf/org/convert.go
+++ b/cmd/exporter/cf/org/convert.go
@@ -4,8 +4,8 @@ import (
 	"log/slog"
 
 	"github.com/SAP/crossplane-provider-cloudfoundry/apis/resources/v1alpha1"
-
 	"github.com/SAP/crossplane-provider-cloudfoundry/cmd/exporter/cf/metadata"
+
 	"github.com/SAP/xp-clifford/yaml"
 	v1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/cmd/exporter/cf/serviceinstance/convert.go
+++ b/cmd/exporter/cf/serviceinstance/convert.go
@@ -5,9 +5,9 @@ import (
 	"log/slog"
 
 	"github.com/SAP/crossplane-provider-cloudfoundry/apis/resources/v1alpha1"
+	"github.com/SAP/crossplane-provider-cloudfoundry/cmd/exporter/cf/metadata"
 	"github.com/SAP/crossplane-provider-cloudfoundry/cmd/exporter/cf/space"
 
-	"github.com/SAP/crossplane-provider-cloudfoundry/cmd/exporter/cf/metadata"
 	"github.com/SAP/xp-clifford/cli/export"
 	"github.com/SAP/xp-clifford/erratt"
 	"github.com/SAP/xp-clifford/yaml"

--- a/cmd/exporter/cf/serviceinstance/convert.go
+++ b/cmd/exporter/cf/serviceinstance/convert.go
@@ -7,6 +7,7 @@ import (
 	"github.com/SAP/crossplane-provider-cloudfoundry/apis/resources/v1alpha1"
 	"github.com/SAP/crossplane-provider-cloudfoundry/cmd/exporter/cf/space"
 
+	"github.com/SAP/crossplane-provider-cloudfoundry/cmd/exporter/cf/metadata"
 	"github.com/SAP/xp-clifford/cli/export"
 	"github.com/SAP/xp-clifford/erratt"
 	"github.com/SAP/xp-clifford/yaml"
@@ -136,7 +137,7 @@ func convertServiceInstanceResource(ctx context.Context, cfClient *client.Client
 				Tags: convertServiceInstanceTags(serviceInstance.Tags),
 				ResourceMetadata: v1alpha1.ResourceMetadata{
 					Annotations: serviceInstance.Metadata.Annotations,
-					Labels:      serviceInstance.Metadata.Labels,
+					Labels:      metadata.StripDefaultLabels(serviceInstance.Metadata.Labels),
 				},
 			},
 		},

--- a/cmd/exporter/cf/space/convert.go
+++ b/cmd/exporter/cf/space/convert.go
@@ -7,6 +7,7 @@ import (
 	"github.com/SAP/crossplane-provider-cloudfoundry/apis/resources/v1alpha1"
 	"github.com/SAP/crossplane-provider-cloudfoundry/cmd/exporter/cf/org"
 
+	"github.com/SAP/crossplane-provider-cloudfoundry/cmd/exporter/cf/metadata"
 	"github.com/SAP/xp-clifford/cli/export"
 	"github.com/SAP/xp-clifford/erratt"
 	"github.com/SAP/xp-clifford/yaml"
@@ -38,7 +39,7 @@ func convertSpaceResource(ctx context.Context, cfClient *client.Client, space *r
 				// AllowSSH:         false,
 				ResourceMetadata: v1alpha1.ResourceMetadata{
 					Annotations: space.Metadata.Annotations,
-					Labels:      space.Metadata.Labels,
+					Labels:      metadata.StripDefaultLabels(space.Metadata.Labels),
 				},
 				IsolationSegment: new(string),
 				Name:             space.Name,

--- a/cmd/exporter/cf/space/convert.go
+++ b/cmd/exporter/cf/space/convert.go
@@ -5,9 +5,9 @@ import (
 	"log/slog"
 
 	"github.com/SAP/crossplane-provider-cloudfoundry/apis/resources/v1alpha1"
+	"github.com/SAP/crossplane-provider-cloudfoundry/cmd/exporter/cf/metadata"
 	"github.com/SAP/crossplane-provider-cloudfoundry/cmd/exporter/cf/org"
 
-	"github.com/SAP/crossplane-provider-cloudfoundry/cmd/exporter/cf/metadata"
 	"github.com/SAP/xp-clifford/cli/export"
 	"github.com/SAP/xp-clifford/erratt"
 	"github.com/SAP/xp-clifford/yaml"


### PR DESCRIPTION
## What
- New `cmd/exporter/cf/metadata/metadata.go` with `StripDefaultLabels` helper
- Strip `crossplane-kind`, `crossplane-name`, `crossplane-providerconfig` from exported CR manifests
- Fix import grouping in exporter convert files (goimports convention)

## Why
Default labels are infrastructure metadata computed by the controller from the CR identity. They are semantically incorrect for a new/exported CR (different name, different ProviderConfig) and the controller will recompute them on the next reconcile.

## Part of
Split from #281 — PR 4 of 6. Depends on [281#1] only (can be merged independently of [281#2] and [281#3]).

**Merge order:** [281#1] → [281#2] → [281#3] → [281#4] → [281#5] → [281#6]