### PR TITLE
[281#5] refactor(route): split GetByIDOrSpec into FindRouteBySpec and GetRouteByGUID

### DIFF
--- a/internal/controller/route/controller_test.go
+++ b/internal/controller/route/controller_test.go
@@ -57,8 +57,6 @@ var (
 	guid       = "33fd5b0b-4f3b-4b1b-8b3d-3b5f7b4b3b4b"
 	name       = "test-route"
 	errBoom    = errors.New("boom")
-
-	nilObservation *v1alpha1.RouteObservation
 )
 
 type modifier func(*v1alpha1.Route)
@@ -168,7 +166,7 @@ func TestObserve(t *testing.T) {
 			service: func() *Mock {
 				m := &Mock{}
 				m.On("FindRouteBySpec", fakeRoute(withHost(name)).Spec.ForProvider).Return(
-					nilObservation, false, nil,
+					(*v1alpha1.RouteObservation)(nil), false, nil,
 				)
 				return m
 			},
@@ -228,7 +226,7 @@ func TestObserve(t *testing.T) {
 			service: func() *Mock {
 				m := &Mock{}
 				m.On("FindRouteBySpec", fakeRoute(withHost(name)).Spec.ForProvider).Return(
-					nilObservation, false, nil,
+					(*v1alpha1.RouteObservation)(nil), false, nil,
 				)
 				return m
 			},
@@ -264,7 +262,7 @@ func TestObserve(t *testing.T) {
 			service: func() *Mock {
 				m := &Mock{}
 				m.On("GetRouteByGUID", guid).Return(
-					nilObservation, false, nil,
+					(*v1alpha1.RouteObservation)(nil), false, nil,
 				)
 				return m
 			},
@@ -292,7 +290,7 @@ func TestObserve(t *testing.T) {
 			service: func() *Mock {
 				m := &Mock{}
 				m.On("GetRouteByGUID", guid).Return(
-					nilObservation, false, errBoom,
+					(*v1alpha1.RouteObservation)(nil), false, errBoom,
 				)
 				return m
 			},


### PR DESCRIPTION
## What
- Remove obsolete `GetByIDOrSpec` from Route service interface
- Use dedicated `FindRouteBySpec` (backwards-compat when external name is empty) and `GetRouteByGUID` (primary path)
- Simplify Org controller GUID validation (fail fast on invalid format)
- Update controller test mocks and expectations

## Why
The hybrid `GetByIDOrSpec` mixed two responsibilities (lookup by spec for adoption, and direct GUID fetch for normal operation). Splitting them clarifies intent and simplifies error handling.

## Part of
Split from #281 — PR 5 of 6 (independent refactor). Depends on [281#3].

**Merge order:** [281#1] → [281#2] → [281#3] → [281#4] → [281#5] → [281#6]