### PR TITLE
[281#6] test: add metadata test coverage (unit, e2e, upgrade)

### DIFF
--- a/internal/clients/domain/domain_test.go
+++ b/internal/clients/domain/domain_test.go
@@ -1,0 +1,295 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/cloudfoundry/go-cfclient/v3/resource"
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/utils/ptr"
+
+	"github.com/SAP/crossplane-provider-cloudfoundry/apis/resources/v1alpha1"
+)
+
+func TestGenerateCreate(t *testing.T) {
+	type args struct {
+		spec v1alpha1.DomainParameters
+	}
+	type want struct {
+		create *resource.DomainCreate
+	}
+
+	cases := map[string]struct {
+		args args
+		want want
+	}{
+		"BasicCreate": {
+			args: args{
+				spec: v1alpha1.DomainParameters{
+					Name: "test.domain.com",
+				},
+			},
+			want: want{
+				create: &resource.DomainCreate{
+					Name:     "test.domain.com",
+					Metadata: &resource.Metadata{},
+				},
+			},
+		},
+		"CreateWithLabels": {
+			args: args{
+				spec: v1alpha1.DomainParameters{
+					Name: "test.domain.com",
+					ResourceMetadata: v1alpha1.ResourceMetadata{
+						Labels: map[string]*string{
+							"env": ptr.To("prod"),
+						},
+					},
+				},
+			},
+			want: want{
+				create: &resource.DomainCreate{
+					Name: "test.domain.com",
+					Metadata: &resource.Metadata{
+						Labels: map[string]*string{
+							"env": ptr.To("prod"),
+						},
+					},
+				},
+			},
+		},
+		"CreateInternalFalseWithRouterGroup": {
+			args: args{
+				spec: v1alpha1.DomainParameters{
+					Name:        "test.domain.com",
+					Internal:    ptr.To(false),
+					RouterGroup: ptr.To("rg-guid"),
+				},
+			},
+			want: want{
+				create: &resource.DomainCreate{
+					Name:        "test.domain.com",
+					Internal:    ptr.To(false),
+					RouterGroup: &resource.Relationship{GUID: "rg-guid"},
+					Metadata:    &resource.Metadata{},
+				},
+			},
+		},
+		"CreateWithOrg": {
+			args: args{
+				spec: v1alpha1.DomainParameters{
+					Name: "test.domain.com",
+					OrgReference: v1alpha1.OrgReference{
+						Org: ptr.To("org-guid"),
+					},
+				},
+			},
+			want: want{
+				create: &resource.DomainCreate{
+					Name: "test.domain.com",
+					Relationships: &resource.DomainRelationships{
+						Organization: &resource.ToOneRelationship{
+							Data: &resource.Relationship{GUID: "org-guid"},
+						},
+					},
+					Metadata: &resource.Metadata{},
+				},
+			},
+		},
+	}
+
+	for n, tc := range cases {
+		t.Run(n, func(t *testing.T) {
+			result := GenerateCreate(nil, tc.args.spec)
+			if diff := cmp.Diff(tc.want.create, result); diff != "" {
+				t.Errorf("GenerateCreate(...): -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGenerateUpdate(t *testing.T) {
+	type args struct {
+		spec v1alpha1.DomainParameters
+	}
+	type want struct {
+		update *resource.DomainUpdate
+	}
+
+	cases := map[string]struct {
+		args args
+		want want
+	}{
+		"BasicUpdate": {
+			args: args{
+				spec: v1alpha1.DomainParameters{
+					Name: "test.domain.com",
+				},
+			},
+			want: want{
+				update: &resource.DomainUpdate{
+					Metadata: &resource.Metadata{},
+				},
+			},
+		},
+		"UpdateWithLabels": {
+			args: args{
+				spec: v1alpha1.DomainParameters{
+					Name: "test.domain.com",
+					ResourceMetadata: v1alpha1.ResourceMetadata{
+						Labels: map[string]*string{
+							"env": ptr.To("prod"),
+						},
+					},
+				},
+			},
+			want: want{
+				update: &resource.DomainUpdate{
+					Metadata: &resource.Metadata{
+						Labels: map[string]*string{
+							"env": ptr.To("prod"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for n, tc := range cases {
+		t.Run(n, func(t *testing.T) {
+			result := GenerateUpdate(nil, tc.args.spec)
+			if diff := cmp.Diff(tc.want.update, result); diff != "" {
+				t.Errorf("GenerateUpdate(...): -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGenerateObservation(t *testing.T) {
+	cases := map[string]struct {
+		domain     *resource.Domain
+		wantID     string
+		wantName   string
+		wantLabels map[string]*string
+		wantAnns   map[string]*string
+	}{
+		"WithMetadata": {
+			domain: &resource.Domain{
+				Name: "test.domain.com",
+				Metadata: &resource.Metadata{
+					Labels:      map[string]*string{"env": ptr.To("prod")},
+					Annotations: map[string]*string{"note": ptr.To("test")},
+				},
+				Resource: resource.Resource{GUID: "domain-guid"},
+			},
+			wantID:     "domain-guid",
+			wantName:   "test.domain.com",
+			wantLabels: map[string]*string{"env": ptr.To("prod")},
+			wantAnns:   map[string]*string{"note": ptr.To("test")},
+		},
+		"NilMetadata": {
+			domain: &resource.Domain{
+				Name:     "test.domain.com",
+				Resource: resource.Resource{GUID: "domain-guid"},
+			},
+			wantID:   "domain-guid",
+			wantName: "test.domain.com",
+		},
+	}
+
+	for n, tc := range cases {
+		t.Run(n, func(t *testing.T) {
+			result := GenerateObservation(tc.domain)
+			if result.ID == nil || *result.ID != tc.wantID {
+				t.Errorf("ID: want %q, got %v", tc.wantID, result.ID)
+			}
+			if result.Name == nil || *result.Name != tc.wantName {
+				t.Errorf("Name: want %q, got %v", tc.wantName, result.Name)
+			}
+			if diff := cmp.Diff(tc.wantLabels, result.Labels); diff != "" {
+				t.Errorf("Labels: -want, +got:\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.wantAnns, result.Annotations); diff != "" {
+				t.Errorf("Annotations: -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestIsUpToDate(t *testing.T) {
+	cases := map[string]struct {
+		spec     v1alpha1.DomainParameters
+		observed *resource.Domain
+		want     bool
+	}{
+		"NilObserved": {
+			spec:     v1alpha1.DomainParameters{Name: "test.domain.com"},
+			observed: nil,
+			want:     false,
+		},
+		"UpToDateNoLabels": {
+			spec:     v1alpha1.DomainParameters{Name: "test.domain.com"},
+			observed: &resource.Domain{Name: "test.domain.com"},
+			want:     true,
+		},
+		"LabelDrift": {
+			spec: v1alpha1.DomainParameters{
+				Name: "test.domain.com",
+				ResourceMetadata: v1alpha1.ResourceMetadata{
+					Labels: map[string]*string{"env": ptr.To("prod")},
+				},
+			},
+			observed: &resource.Domain{Name: "test.domain.com"},
+			want:     false,
+		},
+		"LabelsMatch": {
+			spec: v1alpha1.DomainParameters{
+				Name: "test.domain.com",
+				ResourceMetadata: v1alpha1.ResourceMetadata{
+					Labels: map[string]*string{"env": ptr.To("prod")},
+				},
+			},
+			observed: &resource.Domain{
+				Name:     "test.domain.com",
+				Metadata: &resource.Metadata{Labels: map[string]*string{"env": ptr.To("prod")}},
+			},
+			want: true,
+		},
+		"AnnotationDrift": {
+			spec: v1alpha1.DomainParameters{
+				Name: "test.domain.com",
+				ResourceMetadata: v1alpha1.ResourceMetadata{
+					Annotations: map[string]*string{"note": ptr.To("value")},
+				},
+			},
+			observed: &resource.Domain{Name: "test.domain.com"},
+			want:     false,
+		},
+		"AnnotationsMatch": {
+			spec: v1alpha1.DomainParameters{
+				Name: "test.domain.com",
+				ResourceMetadata: v1alpha1.ResourceMetadata{
+					Annotations: map[string]*string{"note": ptr.To("value")},
+				},
+			},
+			observed: &resource.Domain{
+				Name:     "test.domain.com",
+				Metadata: &resource.Metadata{Annotations: map[string]*string{"note": ptr.To("value")}},
+			},
+			want: true,
+		},
+		"ObservedNilMetadata": {
+			spec:     v1alpha1.DomainParameters{Name: "test.domain.com"},
+			observed: &resource.Domain{Name: "test.domain.com"},
+			want:     true,
+		},
+	}
+
+	for n, tc := range cases {
+		t.Run(n, func(t *testing.T) {
+			result := IsUpToDate(nil, tc.spec, tc.observed)
+			if result != tc.want {
+				t.Errorf("IsUpToDate(...): want %v, got %v", tc.want, result)
+			}
+		})
+	}
+}

--- a/internal/clients/serviceinstance/serviceinstance_test.go
+++ b/internal/clients/serviceinstance/serviceinstance_test.go
@@ -466,3 +466,116 @@ func TestUpdateSharedSpaces(t *testing.T) {
 		})
 	}
 }
+
+func TestIsUpToDate_Metadata(t *testing.T) {
+	cases := map[string]struct {
+		in       *v1alpha1.ServiceInstanceParameters
+		observed *resource.ServiceInstance
+		want     bool
+	}{
+		"UpToDate no labels": {
+			in: &v1alpha1.ServiceInstanceParameters{
+				Name: ptr.To("test-si"),
+				Type: v1alpha1.ManagedService,
+			},
+			observed: &resource.ServiceInstance{
+				Name: "test-si",
+				Type: "managed",
+			},
+			want: true,
+		},
+		"Label drift - spec has labels but observed does not": {
+			in: &v1alpha1.ServiceInstanceParameters{
+				Name: ptr.To("test-si"),
+				Type: v1alpha1.ManagedService,
+				ResourceMetadata: v1alpha1.ResourceMetadata{
+					Labels: map[string]*string{"env": ptr.To("prod")},
+				},
+			},
+			observed: &resource.ServiceInstance{
+				Name: "test-si",
+				Type: "managed",
+			},
+			want: false,
+		},
+		"Labels match": {
+			in: &v1alpha1.ServiceInstanceParameters{
+				Name: ptr.To("test-si"),
+				Type: v1alpha1.ManagedService,
+				ResourceMetadata: v1alpha1.ResourceMetadata{
+					Labels: map[string]*string{"env": ptr.To("prod")},
+				},
+			},
+			observed: &resource.ServiceInstance{
+				Name: "test-si",
+				Type: "managed",
+				Metadata: &resource.Metadata{
+					Labels: map[string]*string{"env": ptr.To("prod")},
+				},
+			},
+			want: true,
+		},
+		"Annotation drift - spec has annotations but observed does not": {
+			in: &v1alpha1.ServiceInstanceParameters{
+				Name: ptr.To("test-si"),
+				Type: v1alpha1.ManagedService,
+				ResourceMetadata: v1alpha1.ResourceMetadata{
+					Annotations: map[string]*string{"note": ptr.To("value")},
+				},
+			},
+			observed: &resource.ServiceInstance{
+				Name: "test-si",
+				Type: "managed",
+			},
+			want: false,
+		},
+		"Annotations match": {
+			in: &v1alpha1.ServiceInstanceParameters{
+				Name: ptr.To("test-si"),
+				Type: v1alpha1.ManagedService,
+				ResourceMetadata: v1alpha1.ResourceMetadata{
+					Annotations: map[string]*string{"note": ptr.To("value")},
+				},
+			},
+			observed: &resource.ServiceInstance{
+				Name: "test-si",
+				Type: "managed",
+				Metadata: &resource.Metadata{
+					Annotations: map[string]*string{"note": ptr.To("value")},
+				},
+			},
+			want: true,
+		},
+		"Observed nil metadata": {
+			in: &v1alpha1.ServiceInstanceParameters{
+				Name: ptr.To("test-si"),
+				Type: v1alpha1.ManagedService,
+			},
+			observed: &resource.ServiceInstance{
+				Name: "test-si",
+				Type: "managed",
+			},
+			want: true,
+		},
+		"Spec name drift": {
+			in: &v1alpha1.ServiceInstanceParameters{
+				Name: ptr.To("new-name"),
+				Type: v1alpha1.ManagedService,
+			},
+			observed: &resource.ServiceInstance{
+				Name: "old-name",
+				Type: "managed",
+			},
+			want: false,
+		},
+	}
+
+	for n, tc := range cases {
+		t.Run(n, func(t *testing.T) {
+			result := IsUpToDate(nil, tc.in, tc.observed)
+			if result != tc.want {
+				t.Errorf("IsUpToDate(...): want %v, got %v", tc.want, result)
+			}
+		})
+	}
+}

--- a/internal/clients/space/space_test.go
+++ b/internal/clients/space/space_test.go
@@ -1,0 +1,333 @@
+package space
+
+import (
+	"testing"
+
+	"github.com/cloudfoundry/go-cfclient/v3/resource"
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/utils/ptr"
+
+	"github.com/SAP/crossplane-provider-cloudfoundry/apis/resources/v1alpha1"
+)
+
+func TestGenerateCreate(t *testing.T) {
+	type args struct {
+		spec v1alpha1.SpaceParameters
+	}
+	type want struct {
+		create *resource.SpaceCreate
+	}
+
+	cases := map[string]struct {
+		args args
+		want want
+	}{
+		"BasicCreate": {
+			args: args{
+				spec: v1alpha1.SpaceParameters{
+					Name: "test-space",
+					OrgReference: v1alpha1.OrgReference{
+						Org: ptr.To("test-org-guid"),
+					},
+				},
+			},
+			want: want{
+				create: func() *resource.SpaceCreate {
+					c := resource.NewSpaceCreate("test-space", "test-org-guid")
+					c.Metadata = &resource.Metadata{}
+					return c
+				}(),
+			},
+		},
+		"CreateWithLabels": {
+			args: args{
+				spec: v1alpha1.SpaceParameters{
+					Name: "test-space",
+					OrgReference: v1alpha1.OrgReference{
+						Org: ptr.To("test-org-guid"),
+					},
+					ResourceMetadata: v1alpha1.ResourceMetadata{
+						Labels: map[string]*string{
+							"env": ptr.To("prod"),
+						},
+					},
+				},
+			},
+			want: want{
+				create: func() *resource.SpaceCreate {
+					c := resource.NewSpaceCreate("test-space", "test-org-guid")
+					c.Metadata = &resource.Metadata{
+						Labels: map[string]*string{
+							"env": ptr.To("prod"),
+						},
+					}
+					return c
+				}(),
+			},
+		},
+		"CreateWithLabelsAndAnnotations": {
+			args: args{
+				spec: v1alpha1.SpaceParameters{
+					Name: "test-space",
+					OrgReference: v1alpha1.OrgReference{
+						Org: ptr.To("test-org-guid"),
+					},
+					ResourceMetadata: v1alpha1.ResourceMetadata{
+						Labels: map[string]*string{
+							"env": ptr.To("staging"),
+						},
+						Annotations: map[string]*string{
+							"note": ptr.To("test-annotation"),
+						},
+					},
+				},
+			},
+			want: want{
+				create: func() *resource.SpaceCreate {
+					c := resource.NewSpaceCreate("test-space", "test-org-guid")
+					c.Metadata = &resource.Metadata{
+						Labels: map[string]*string{
+							"env": ptr.To("staging"),
+						},
+						Annotations: map[string]*string{
+							"note": ptr.To("test-annotation"),
+						},
+					}
+					return c
+				}(),
+			},
+		},
+	}
+
+	for n, tc := range cases {
+		t.Run(n, func(t *testing.T) {
+			result := GenerateCreate(nil, tc.args.spec)
+			if diff := cmp.Diff(tc.want.create, result); diff != "" {
+				t.Errorf("GenerateCreate(...): -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGenerateUpdate(t *testing.T) {
+	type args struct {
+		spec v1alpha1.SpaceParameters
+	}
+	type want struct {
+		update *resource.SpaceUpdate
+	}
+
+	cases := map[string]struct {
+		args args
+		want want
+	}{
+		"BasicUpdate": {
+			args: args{
+				spec: v1alpha1.SpaceParameters{
+					Name: "test-space",
+				},
+			},
+			want: want{
+				update: &resource.SpaceUpdate{
+					Name:     "test-space",
+					Metadata: &resource.Metadata{},
+				},
+			},
+		},
+		"UpdateWithLabels": {
+			args: args{
+				spec: v1alpha1.SpaceParameters{
+					Name: "test-space",
+					ResourceMetadata: v1alpha1.ResourceMetadata{
+						Labels: map[string]*string{
+							"env": ptr.To("prod"),
+						},
+					},
+				},
+			},
+			want: want{
+				update: &resource.SpaceUpdate{
+					Name: "test-space",
+					Metadata: &resource.Metadata{
+						Labels: map[string]*string{
+							"env": ptr.To("prod"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for n, tc := range cases {
+		t.Run(n, func(t *testing.T) {
+			result := GenerateUpdate(nil, tc.args.spec)
+			if diff := cmp.Diff(tc.want.update, result); diff != "" {
+				t.Errorf("GenerateUpdate(...): -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGenerateObservation(t *testing.T) {
+	cases := map[string]struct {
+		space      *resource.Space
+		ssh        bool
+		wantID     string
+		wantName   string
+		wantOrg    string
+		wantSSH    bool
+		wantLabels map[string]*string
+		wantAnns   map[string]*string
+	}{
+		"WithMetadata": {
+			space: &resource.Space{
+				Name: "test-space",
+				Relationships: &resource.SpaceRelationships{
+					Organization: &resource.ToOneRelationship{Data: &resource.Relationship{GUID: "org-guid"}},
+				},
+				Metadata: &resource.Metadata{
+					Labels:      map[string]*string{"env": ptr.To("prod")},
+					Annotations: map[string]*string{"note": ptr.To("test")},
+				},
+				Resource: resource.Resource{GUID: "space-guid"},
+			},
+			ssh:        true,
+			wantID:     "space-guid",
+			wantName:   "test-space",
+			wantOrg:    "org-guid",
+			wantSSH:    true,
+			wantLabels: map[string]*string{"env": ptr.To("prod")},
+			wantAnns:   map[string]*string{"note": ptr.To("test")},
+		},
+		"NilMetadata": {
+			space: &resource.Space{
+				Name: "test-space",
+				Relationships: &resource.SpaceRelationships{
+					Organization: &resource.ToOneRelationship{Data: &resource.Relationship{GUID: "org-guid"}},
+				},
+				Resource: resource.Resource{GUID: "space-guid"},
+			},
+			ssh:      false,
+			wantID:   "space-guid",
+			wantName: "test-space",
+			wantOrg:  "org-guid",
+		},
+	}
+
+	for n, tc := range cases {
+		t.Run(n, func(t *testing.T) {
+			result := GenerateObservation(tc.space, tc.ssh)
+			if result.ID != tc.wantID {
+				t.Errorf("ID: want %q, got %q", tc.wantID, result.ID)
+			}
+			if result.Name != tc.wantName {
+				t.Errorf("Name: want %q, got %q", tc.wantName, result.Name)
+			}
+			if result.Org != tc.wantOrg {
+				t.Errorf("Org: want %q, got %q", tc.wantOrg, result.Org)
+			}
+			if result.AllowSSH != tc.wantSSH {
+				t.Errorf("AllowSSH: want %v, got %v", tc.wantSSH, result.AllowSSH)
+			}
+			if diff := cmp.Diff(tc.wantLabels, result.Labels); diff != "" {
+				t.Errorf("Labels: -want, +got:\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.wantAnns, result.Annotations); diff != "" {
+				t.Errorf("Annotations: -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestIsUpToDate(t *testing.T) {
+	cases := map[string]struct {
+		spec     v1alpha1.SpaceParameters
+		observed *resource.Space
+		ssh      bool
+		want     bool
+	}{
+		"UpToDateNoLabels": {
+			spec:     v1alpha1.SpaceParameters{Name: "test-space"},
+			observed: &resource.Space{Name: "test-space"},
+			ssh:      false,
+			want:     true,
+		},
+		"NameDrift": {
+			spec:     v1alpha1.SpaceParameters{Name: "new-name"},
+			observed: &resource.Space{Name: "old-name"},
+			ssh:      false,
+			want:     false,
+		},
+		"SSHDrift": {
+			spec:     v1alpha1.SpaceParameters{Name: "test-space", AllowSSH: true},
+			observed: &resource.Space{Name: "test-space"},
+			ssh:      false,
+			want:     false,
+		},
+		"LabelDrift": {
+			spec: v1alpha1.SpaceParameters{
+				Name: "test-space",
+				ResourceMetadata: v1alpha1.ResourceMetadata{
+					Labels: map[string]*string{"env": ptr.To("prod")},
+				},
+			},
+			observed: &resource.Space{Name: "test-space"},
+			ssh:      false,
+			want:     false,
+		},
+		"LabelsMatch": {
+			spec: v1alpha1.SpaceParameters{
+				Name: "test-space",
+				ResourceMetadata: v1alpha1.ResourceMetadata{
+					Labels: map[string]*string{"env": ptr.To("prod")},
+				},
+			},
+			observed: &resource.Space{
+				Name:     "test-space",
+				Metadata: &resource.Metadata{Labels: map[string]*string{"env": ptr.To("prod")}},
+			},
+			ssh:  false,
+			want: true,
+		},
+		"AnnotationDrift": {
+			spec: v1alpha1.SpaceParameters{
+				Name: "test-space",
+				ResourceMetadata: v1alpha1.ResourceMetadata{
+					Annotations: map[string]*string{"note": ptr.To("value")},
+				},
+			},
+			observed: &resource.Space{Name: "test-space"},
+			ssh:      false,
+			want:     false,
+		},
+		"AnnotationsMatch": {
+			spec: v1alpha1.SpaceParameters{
+				Name: "test-space",
+				ResourceMetadata: v1alpha1.ResourceMetadata{
+					Annotations: map[string]*string{"note": ptr.To("value")},
+				},
+			},
+			observed: &resource.Space{
+				Name:     "test-space",
+				Metadata: &resource.Metadata{Annotations: map[string]*string{"note": ptr.To("value")}},
+			},
+			ssh:  false,
+			want: true,
+		},
+		"ObservedNilMetadata": {
+			spec:     v1alpha1.SpaceParameters{Name: "test-space"},
+			observed: &resource.Space{Name: "test-space"},
+			ssh:      false,
+			want:     true,
+		},
+	}
+
+	for n, tc := range cases {
+		t.Run(n, func(t *testing.T) {
+			result := IsUpToDate(nil, tc.spec, tc.observed, tc.ssh)
+			if result != tc.want {
+				t.Errorf("IsUpToDate(...): want %v, got %v", tc.want, result)
+			}
+		})
+	}
+}

--- a/test/e2e/cloudfoundry_app_test.go
+++ b/test/e2e/cloudfoundry_app_test.go
@@ -70,7 +70,6 @@ func TestCloudfoundry_App(t *testing.T) {
 				if err := cr.Get(ctx, ft.name, cfg.Namespace(), ft.obj); err != nil {
 					t.Errorf("error observing resource %s: %s", ft.obj.GetName(), err.Error())
 				}
-				//klog.InfoS("resourced details", "cr", ft.obj)
 				return ctx
 			}).Assess(name+":"+ft.name+" ready",
 			func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
@@ -80,6 +79,7 @@ func TestCloudfoundry_App(t *testing.T) {
 				if err := wait.For(ResourceReady(cfg, ft.obj), wait.WithTimeout(10*time.Minute)); err != nil {
 					t.Errorf("error waiting for resource %s to be ready: %s", ft.obj.GetName(), err.Error())
 				}
+				checkAppResourceLabelsAndAnnotations(ctx, t, cfg, ft.obj, name)
 				return ctx
 			})
 	}
@@ -197,4 +197,32 @@ func hosts(routes []v1alpha1.AppRouteObservation) []string {
 			yield(r.Host)
 		}
 	})
+}
+
+func checkAppResourceLabelsAndAnnotations(ctx context.Context, t *testing.T, cfg *envconf.Config, obj k8s.Object, stepName string) {
+	cr := cfg.Client().Resources()
+	switch v := obj.(type) {
+	case *v1alpha1.App:
+		if err := cr.Get(ctx, v.GetName(), cfg.Namespace(), v); err != nil {
+			t.Errorf("error getting App for label check: %s", err.Error())
+			return
+		}
+		description := "E2E test app"
+		if stepName == "app-2" {
+			description = "E2E test app 2"
+		}
+		if err := AssertLabelsAndAnnotations(
+			v.Status.AtProvider.Labels,
+			v.Status.AtProvider.Annotations,
+			map[string]string{"environment": "test", "team": "platform"},
+			map[string]string{"description": description},
+			v.GetName(),
+			"app.cloudfoundry.crossplane.io",
+			v.GetProviderConfigReference().Name,
+		); err != nil {
+			t.Errorf("App %s labels/annotations check failed: %s", v.GetName(), err.Error())
+		}
+	default:
+		// Observe-only resources (Space, Domain, ServiceInstance, SCB) and other non-eligible types — skip
+	}
 }

--- a/test/e2e/cloudfoundry_orgspace_test.go
+++ b/test/e2e/cloudfoundry_orgspace_test.go
@@ -71,7 +71,6 @@ func TestCloudFoundryOrgSpace(t *testing.T) {
 				if err := cr.Get(ctx, ft.name, cfg.Namespace(), ft.obj); err != nil {
 					t.Errorf("error observing resource %s: %s", ft.obj.GetName(), err.Error())
 				}
-				//klog.InfoS("resourced details", "cr", ft.obj)
 				return ctx
 			}).Assess(name+":"+ft.name+" ready",
 			func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
@@ -81,6 +80,8 @@ func TestCloudFoundryOrgSpace(t *testing.T) {
 				if err := wait.For(ResourceReady(cfg, ft.obj), wait.WithTimeout(10*time.Minute)); err != nil {
 					t.Errorf("error waiting for resource %s to be ready: %s", ft.obj.GetName(), err.Error())
 				}
+				// Check labels and annotations for eligible resources
+				checkResourceLabelsAndAnnotations(ctx, t, cfg, ft.obj, name)
 				return ctx
 			})
 	}
@@ -136,4 +137,46 @@ func TestCloudFoundryOrgSpace(t *testing.T) {
 	}
 
 	testenv.Test(t, feat.Feature())
+}
+
+// checkResourceLabelsAndAnnotations verifies user-provided labels/annotations and
+// default Crossplane labels for eligible resources (those with CF Metadata support).
+func checkResourceLabelsAndAnnotations(ctx context.Context, t *testing.T, cfg *envconf.Config, obj k8s.Object, stepName string) {
+	cr := cfg.Client().Resources()
+	switch v := obj.(type) {
+	case *v1alpha1.Space:
+		if err := cr.Get(ctx, v.GetName(), cfg.Namespace(), v); err != nil {
+			t.Errorf("error getting Space for label check: %s", err.Error())
+			return
+		}
+		if stepName == "space" {
+			// e2e-space-org-ref
+			if err := AssertLabelsAndAnnotations(
+				v.Status.AtProvider.Labels,
+				v.Status.AtProvider.Annotations,
+				map[string]string{"environment": "test", "team": "platform"},
+				map[string]string{"description": "E2E test space with org ref"},
+				v.GetName(),
+				"space.cloudfoundry.crossplane.io",
+				v.GetProviderConfigReference().Name,
+			); err != nil {
+				t.Errorf("Space %s labels/annotations check failed: %s", v.GetName(), err.Error())
+			}
+		} else {
+			// e2e-space-org-name
+			if err := AssertLabelsAndAnnotations(
+				v.Status.AtProvider.Labels,
+				v.Status.AtProvider.Annotations,
+				map[string]string{"environment": "staging", "team": "devops"},
+				map[string]string{"description": "E2E test space with org name"},
+				v.GetName(),
+				"space.cloudfoundry.crossplane.io",
+				v.GetProviderConfigReference().Name,
+			); err != nil {
+				t.Errorf("Space %s labels/annotations check failed: %s", v.GetName(), err.Error())
+			}
+		}
+	default:
+		// Not an eligible resource type (OrgRole, SpaceRole, etc.) — skip label checks
+	}
 }

--- a/test/e2e/cloudfoundry_serviceroutebinding_test.go
+++ b/test/e2e/cloudfoundry_serviceroutebinding_test.go
@@ -5,14 +5,13 @@ package e2e
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"testing"
 	"time"
 
-	meta "github.com/SAP/crossplane-provider-cloudfoundry/apis"
 	"sigs.k8s.io/e2e-framework/klient/decoder"
 	"sigs.k8s.io/e2e-framework/klient/k8s"
-	resources "sigs.k8s.io/e2e-framework/klient/k8s/resources"
 	"sigs.k8s.io/e2e-framework/klient/wait"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/envfuncs"
@@ -83,26 +82,43 @@ func TestCloudFoundryServiceRouteBinding(t *testing.T) {
 				if err := wait.For(ResourceReady(cfg, ft.obj), wait.WithTimeout(10*time.Minute)); err != nil {
 					t.Errorf("error waiting for resource %s to be ready: %s", ft.obj.GetName(), err.Error())
 				}
+				checkSRBResourceLabelsAndAnnotations(ctx, t, cfg, ft.obj)
 				return ctx
 			})
 	}
 
-	// Test metadata update by applying updated manifest
+	// Test metadata update: decode updated manifest, then update the existing CR
 	feat.Assess("service_route_binding:e2e-serviceroutebinding-binding apply metadata update",
 		func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-			r, _ := resources.New(cfg.Client().RESTConfig())
-			_ = meta.AddToScheme(r.GetScheme())
-			r.WithNamespace(cfg.Namespace())
-
+			// Decode the updated manifest to get the desired labels/annotations
+			updated := &v1alpha1.ServiceRouteBinding{}
 			err := decoder.DecodeEachFile(
-				ctx, os.DirFS(dir), "serviceroutebinding-updated.yaml",
-				decoder.CreateIgnoreAlreadyExists(r),
+				ctx, os.DirFS(dir+"/updated"), "serviceroutebinding-updated.yaml",
+				func(ctx context.Context, obj k8s.Object) error {
+					updated = obj.(*v1alpha1.ServiceRouteBinding)
+					return nil
+				},
 				decoder.MutateNamespace(cfg.Namespace()),
 			)
 			if err != nil {
-				t.Errorf("error applying updated manifest: %s", err.Error())
+				t.Fatalf("error decoding updated manifest: %s", err.Error())
 			}
-			t.Logf("Applied updated metadata manifest")
+
+			// Get the existing CR (preserving resourceVersion)
+			existing := &v1alpha1.ServiceRouteBinding{}
+			cr := cfg.Client().Resources()
+			if err := cr.Get(ctx, "e2e-serviceroutebinding-binding", cfg.Namespace(), existing); err != nil {
+				t.Fatalf("error getting existing SRB: %s", err.Error())
+			}
+
+			// Apply updated labels/annotations from the manifest
+			existing.Spec.ForProvider.Labels = updated.Spec.ForProvider.Labels
+			existing.Spec.ForProvider.Annotations = updated.Spec.ForProvider.Annotations
+
+			if err := cr.Update(ctx, existing); err != nil {
+				t.Fatalf("error updating SRB with new labels: %s", err.Error())
+			}
+			t.Logf("Applied updated metadata to SRB")
 			return ctx
 		}).Assess("service_route_binding:e2e-serviceroutebinding-binding ready after metadata update",
 		func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
@@ -112,6 +128,31 @@ func TestCloudFoundryServiceRouteBinding(t *testing.T) {
 			t.Logf("Waiting for resource to be ready after metadata update")
 			if err := wait.For(ResourceReady(cfg, binding), wait.WithTimeout(10*time.Minute)); err != nil {
 				t.Errorf("error waiting for resource to be ready after update: %s", err.Error())
+			}
+			// Poll until updated labels/annotations appear in status
+			if err := wait.For(func(ctx context.Context) (bool, error) {
+				cr := cfg.Client().Resources()
+				if err := cr.Get(ctx, "e2e-serviceroutebinding-binding", cfg.Namespace(), binding); err != nil {
+					return false, err
+				}
+				labelBytes, _ := json.MarshalIndent(binding.Status.AtProvider.Labels, "", " ")
+				annotationBytes, _ := json.MarshalIndent(binding.Status.AtProvider.Annotations, "", " ")
+				t.Logf("Current labels for %s: %s", binding.GetName(), string(labelBytes))
+				t.Logf("Current annotations for %s: %s", binding.GetName(), string(annotationBytes))
+				if err := AssertLabelsAndAnnotations(
+					binding.Status.AtProvider.Labels,
+					binding.Status.AtProvider.Annotations,
+					map[string]string{"environment": "production", "team": "operations"},
+					map[string]string{"description": "Updated metadata"},
+					binding.GetName(),
+					"serviceroutebinding.cloudfoundry.crossplane.io",
+					binding.GetProviderConfigReference().Name,
+				); err != nil {
+					return false, nil // not yet reconciled
+				}
+				return true, nil
+			}, wait.WithTimeout(5*time.Minute)); err != nil {
+				t.Errorf("SRB after update labels/annotations check failed: %s", err.Error())
 			}
 			return ctx
 		})
@@ -141,4 +182,57 @@ func TestCloudFoundryServiceRouteBinding(t *testing.T) {
 	}
 
 	testenv.Test(t, feat.Feature())
+}
+
+// checkSRBResourceLabelsAndAnnotations verifies default Crossplane labels
+// for all eligible resources in the SRB test, and user-provided labels/annotations
+// for resources that have them in their manifests.
+func checkSRBResourceLabelsAndAnnotations(ctx context.Context, t *testing.T, cfg *envconf.Config, obj k8s.Object) {
+	cr := cfg.Client().Resources()
+	switch v := obj.(type) {
+	case *v1alpha1.ServiceRouteBinding:
+		if err := cr.Get(ctx, v.GetName(), cfg.Namespace(), v); err != nil {
+			t.Errorf("error getting SRB for label check: %s", err.Error())
+			return
+		}
+		if err := AssertLabelsAndAnnotations(
+			v.Status.AtProvider.Labels,
+			v.Status.AtProvider.Annotations,
+			map[string]string{"environment": "test", "team": "platform"},
+			map[string]string{"description": "Initial metadata"},
+			v.GetName(),
+			"serviceroutebinding.cloudfoundry.crossplane.io",
+			v.GetProviderConfigReference().Name,
+		); err != nil {
+			t.Errorf("SRB %s labels/annotations check failed: %s", v.GetName(), err.Error())
+		}
+	case *v1alpha1.ServiceInstance:
+		if err := cr.Get(ctx, v.GetName(), cfg.Namespace(), v); err != nil {
+			t.Errorf("error getting SI for label check: %s", err.Error())
+			return
+		}
+		if err := AssertDefaultLabels(
+			v.Status.AtProvider.Labels,
+			v.GetName(),
+			"serviceinstance.cloudfoundry.crossplane.io",
+			v.GetProviderConfigReference().Name,
+		); err != nil {
+			t.Errorf("SI %s default labels check failed: %s", v.GetName(), err.Error())
+		}
+	case *v1alpha1.Route:
+		if err := cr.Get(ctx, v.GetName(), cfg.Namespace(), v); err != nil {
+			t.Errorf("error getting Route for label check: %s", err.Error())
+			return
+		}
+		if err := AssertDefaultLabels(
+			v.Status.AtProvider.Labels,
+			v.GetName(),
+			"route.cloudfoundry.crossplane.io",
+			v.GetProviderConfigReference().Name,
+		); err != nil {
+			t.Errorf("Route %s default labels check failed: %s", v.GetName(), err.Error())
+		}
+	default:
+		// Observe-only resources (Space, Domain, Organization) and non-eligible types — skip
+	}
 }

--- a/test/e2e/cloudfoundry_services_test.go
+++ b/test/e2e/cloudfoundry_services_test.go
@@ -95,7 +95,6 @@ func TestCloudFoundryServices(t *testing.T) {
 				if err := cr.Get(ctx, ft.name, cfg.Namespace(), ft.obj); err != nil {
 					t.Errorf("error observing resource %s: %s", ft.obj.GetName(), err.Error())
 				}
-				//klog.InfoS("resourced details", "cr", ft.obj)
 				return ctx
 			}).Assess(name+":"+ft.name+" ready",
 			func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
@@ -105,6 +104,7 @@ func TestCloudFoundryServices(t *testing.T) {
 				if err := wait.For(ResourceReady(cfg, ft.obj), wait.WithTimeout(10*time.Minute)); err != nil {
 					t.Errorf("error waiting for resource %s to be ready: %s", ft.obj.GetName(), err.Error())
 				}
+				checkServiceResourceLabelsAndAnnotations(ctx, t, cfg, ft.obj, name)
 				return ctx
 			})
 	}
@@ -160,4 +160,60 @@ func TestCloudFoundryServices(t *testing.T) {
 	}
 
 	testenv.Test(t, feat.Feature())
+}
+
+func checkServiceResourceLabelsAndAnnotations(ctx context.Context, t *testing.T, cfg *envconf.Config, obj k8s.Object, stepName string) {
+	cr := cfg.Client().Resources()
+	switch v := obj.(type) {
+	case *v1alpha1.ServiceInstance:
+		if err := cr.Get(ctx, v.GetName(), cfg.Namespace(), v); err != nil {
+			t.Errorf("error getting ServiceInstance for label check: %s", err.Error())
+			return
+		}
+		if stepName == "service_instance" {
+			// Managed SI with user labels in manifest
+			if err := AssertLabelsAndAnnotations(
+				v.Status.AtProvider.Labels,
+				v.Status.AtProvider.Annotations,
+				map[string]string{"environment": "test", "team": "platform"},
+				map[string]string{"description": "E2E test service instance"},
+				v.GetName(),
+				"serviceinstance.cloudfoundry.crossplane.io",
+				v.GetProviderConfigReference().Name,
+			); err != nil {
+				t.Errorf("ServiceInstance %s labels/annotations check failed: %s", v.GetName(), err.Error())
+			}
+		} else {
+			// UPS instances — no user labels in manifest, just check default labels
+			if err := AssertDefaultLabels(
+				v.Status.AtProvider.Labels,
+				v.GetName(),
+				"serviceinstance.cloudfoundry.crossplane.io",
+				v.GetProviderConfigReference().Name,
+			); err != nil {
+				t.Errorf("ServiceInstance %s default labels check failed: %s", v.GetName(), err.Error())
+			}
+		}
+	case *v1alpha1.ServiceCredentialBinding:
+		if err := cr.Get(ctx, v.GetName(), cfg.Namespace(), v); err != nil {
+			t.Errorf("error getting SCB for label check: %s", err.Error())
+			return
+		}
+		if stepName == "scb_key" {
+			// SCB with user labels in manifest
+			if err := AssertLabelsAndAnnotations(
+				v.Status.AtProvider.Labels,
+				v.Status.AtProvider.Annotations,
+				map[string]string{"environment": "test", "team": "platform"},
+				map[string]string{"description": "E2E test service credential binding"},
+				v.GetName(),
+				"servicecredentialbinding.cloudfoundry.crossplane.io",
+				v.GetProviderConfigReference().Name,
+			); err != nil {
+				t.Errorf("SCB %s labels/annotations check failed: %s", v.GetName(), err.Error())
+			}
+		}
+	default:
+		// Observe-only resources (Space) and non-eligible types — skip
+	}
 }

--- a/test/e2e/crs/app/app.yaml
+++ b/test/e2e/crs/app/app.yaml
@@ -22,6 +22,11 @@ spec:
           name: app-route-domainref
           policy:
             resolve: Always
+    labels:
+      environment: test
+      team: platform
+    annotations:
+      description: E2E test app
 
 ---
 apiVersion: cloudfoundry.crossplane.io/v1alpha1
@@ -48,3 +53,8 @@ spec:
           name: app-route-domainname
           policy:
             resolve: Always
+    labels:
+      environment: test
+      team: platform
+    annotations:
+      description: E2E test app 2

--- a/test/e2e/crs/app/route.yaml
+++ b/test/e2e/crs/app/route.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: app-test
 spec:
   forProvider:
-    domainRef: 
+    domainRef:
       name: app-domain
       policy:
         resolve: Always

--- a/test/e2e/crs/orgspace/space.yaml
+++ b/test/e2e/crs/orgspace/space.yaml
@@ -7,7 +7,7 @@ metadata:
   name: e2e-space-org-ref
 spec:
   forProvider:
-    name: e2e-space
+    name: e2e-space-ref
     orgRef:
       name:  e2e-org
       policy:
@@ -26,7 +26,7 @@ metadata:
   name: e2e-space-org-name
 spec:
   forProvider:
-    name: e2e-space
+    name: e2e-space-name
     orgName: cf-ci-e2e
     labels:
       environment: staging

--- a/test/e2e/crs/orgspace/space.yaml
+++ b/test/e2e/crs/orgspace/space.yaml
@@ -12,6 +12,11 @@ spec:
       name:  e2e-org
       policy:
         resolve: Always
+    labels:
+      environment: test
+      team: platform
+    annotations:
+      description: E2E test space with org ref
 ---
 # create a new space with org name
 apiVersion: cloudfoundry.crossplane.io/v1alpha1
@@ -23,3 +28,8 @@ spec:
   forProvider:
     name: e2e-space
     orgName: cf-ci-e2e
+    labels:
+      environment: staging
+      team: devops
+    annotations:
+      description: E2E test space with org name

--- a/test/e2e/crs/service/scb_key.yaml
+++ b/test/e2e/crs/service/scb_key.yaml
@@ -14,6 +14,11 @@ spec:
     rotation:
       frequency: 1h
       ttl: 2h
+    labels:
+      environment: test
+      team: platform
+    annotations:
+      description: E2E test service credential binding
   connectionDetailsAsJSON: false
   writeConnectionSecretToRef:
     name: e2e-service-key

--- a/test/e2e/crs/service/service_instance.yaml
+++ b/test/e2e/crs/service/service_instance.yaml
@@ -19,3 +19,8 @@ spec:
     sharedSpaces:
       - spaceRef:
           name: service-space-shared
+    labels:
+      environment: test
+      team: platform
+    annotations:
+      description: E2E test service instance

--- a/test/e2e/crs/serviceRouteBinding/updated/serviceroutebinding-updated.yaml
+++ b/test/e2e/crs/serviceRouteBinding/updated/serviceroutebinding-updated.yaml
@@ -15,7 +15,6 @@ spec:
         resolve: Always
     labels:
       environment: production
-      managed-by: crossplane
+      team: operations
     annotations:
-      description: Updated metadata for testing updates
-      contact: team@example.com
+      description: Updated metadata

--- a/test/e2e/test_assertions.go
+++ b/test/e2e/test_assertions.go
@@ -4,6 +4,7 @@ package e2e
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	meta "github.com/SAP/crossplane-provider-cloudfoundry/apis"
@@ -35,7 +36,7 @@ func ApplyResources(ctx context.Context, cfg *envconf.Config, dir string) error 
 	)
 }
 
-// ApplyResources delete resources by looping through files in the provided directory.
+// UnapplyResources delete resources by looping through files in the provided directory.
 func UnapplyResources(ctx context.Context, cfg *envconf.Config, dir string) error {
 	r, _ := resources.New(cfg.Client().RESTConfig())
 
@@ -69,4 +70,89 @@ func ResourceReady(cfg *envconf.Config, object k8s.Object) wait2.ConditionWithCo
 func ResourceDeleted(cfg *envconf.Config, object k8s.Object) wait2.ConditionWithContextFunc {
 	var cr = cfg.Client().Resources()
 	return conditions.New(cr).ResourceDeleted(object)
+}
+
+// AssertDefaultLabels checks that the observed labels on a CF resource contain
+// the three Crossplane default labels (crossplane-kind, crossplane-name,
+// crossplane-providerconfig) with the expected values.
+func AssertDefaultLabels(observedLabels map[string]*string, crName, expectedKind, providerConfigName string) error {
+	if observedLabels == nil {
+		return fmt.Errorf("observed labels map is nil for resource %s", crName)
+	}
+
+	type check struct {
+		key   string
+		value string
+	}
+	checks := []check{
+		{key: "crossplane-kind", value: expectedKind},
+		{key: "crossplane-name", value: crName},
+	}
+	if providerConfigName != "" {
+		checks = append(checks, check{key: "crossplane-providerconfig", value: providerConfigName})
+	}
+
+	for _, c := range checks {
+		val, exists := observedLabels[c.key]
+		if !exists {
+			return fmt.Errorf("resource %s missing default label %q", crName, c.key)
+		}
+		if val == nil || *val != c.value {
+			actual := "<nil>"
+			if val != nil {
+				actual = *val
+			}
+			return fmt.Errorf("resource %s label %q: expected %q, got %q", crName, c.key, c.value, actual)
+		}
+	}
+	return nil
+}
+
+// assertObservedValue checks that observed[key] exists and equals value.
+func assertObservedValue(observed map[string]*string, key, value, crName string) error {
+	if observed == nil {
+		return fmt.Errorf("observed map is nil for resource %s", crName)
+	}
+	val, exists := observed[key]
+	if !exists {
+		return fmt.Errorf("resource %s missing key %q", crName, key)
+	}
+	if val == nil || *val != value {
+		actual := "<nil>"
+		if val != nil {
+			actual = *val
+		}
+		return fmt.Errorf("resource %s key %q: expected %q, got %q", crName, key, value, actual)
+	}
+	return nil
+}
+
+// AssertLabelsAndAnnotations checks both user-provided and default Crossplane labels,
+// plus user-provided annotations on an eligible CF resource.
+// expectedLabels/expectedAnnotations are the user-provided key-value pairs expected in observation.
+// expectedKind is the lowercase GVK string like "space.cloudfoundry.crossplane.io".
+func AssertLabelsAndAnnotations(
+	observedLabels map[string]*string,
+	observedAnnotations map[string]*string,
+	expectedLabels map[string]string,
+	expectedAnnotations map[string]string,
+	crName, expectedKind, providerConfigName string,
+) error {
+	// Check default Crossplane labels
+	if err := AssertDefaultLabels(observedLabels, crName, expectedKind, providerConfigName); err != nil {
+		return err
+	}
+	// Check user-provided labels
+	for k, v := range expectedLabels {
+		if err := assertObservedValue(observedLabels, k, v, crName); err != nil {
+			return fmt.Errorf("user label check failed: %w", err)
+		}
+	}
+	// Check user-provided annotations
+	for k, v := range expectedAnnotations {
+		if err := assertObservedValue(observedAnnotations, k, v, crName); err != nil {
+			return fmt.Errorf("user annotation check failed: %w", err)
+		}
+	}
+	return nil
 }

--- a/test/upgrade/label_upgrade_test.go
+++ b/test/upgrade/label_upgrade_test.go
@@ -1,0 +1,125 @@
+//go:build upgrade
+
+//
+// This file (label_upgrade_test.go) contains Test_Label_Migration,
+// which validates that default Crossplane labels (crossplane-kind,
+// crossplane-name, crossplane-providerconfig) are correctly applied
+// to existing resources after a provider upgrade.
+//
+// Pre-upgrade: Resources created by the old provider version do not have
+// default Crossplane labels. Post-upgrade: The new provider reconciles and
+// adds the 3 default labels to the external CF resource.
+
+package upgrade
+
+import (
+	"context"
+	"testing"
+
+	v1alpha1 "github.com/SAP/crossplane-provider-cloudfoundry/apis/resources/v1alpha1"
+	"github.com/crossplane/crossplane-runtime/pkg/resource"
+	"k8s.io/klog/v2"
+	res "sigs.k8s.io/e2e-framework/klient/k8s/resources"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+)
+
+var (
+	labelResourceDirectories = []string{
+		"./testdata/customCrs/labels/import",
+		"./testdata/customCrs/labels/space",
+	}
+)
+
+func Test_Label_Migration(t *testing.T) {
+	const spaceName = "upgrade-test-space"
+
+	upgradeTest := NewCustomUpgradeTest("label-migration-test").
+		FromVersion(fromTag).
+		ToVersion(toTag).
+		WithResourceDirectories(labelResourceDirectories).
+		WithCustomPreUpgradeAssessment(
+			"Verify no crossplane labels before upgrade",
+			func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+				r, err := res.New(cfg.Client().RESTConfig())
+				if err != nil {
+					t.Fatalf("Failed to create resource client: %v", err)
+				}
+
+				err = v1alpha1.SchemeBuilder.AddToScheme(r.GetScheme())
+				if err != nil {
+					t.Fatalf("Failed to add CloudFoundry scheme: %v", err)
+				}
+
+				space := &v1alpha1.Space{}
+				err = r.Get(ctx, spaceName, cfg.Namespace(), space)
+				if err != nil {
+					t.Fatalf("Failed to get Space resource: %v", err)
+				}
+
+				// Verify no crossplane-* default labels exist in observation
+				labels := space.Status.AtProvider.Labels
+				for key := range labels {
+					if key == resource.ExternalResourceTagKeyKind ||
+						key == resource.ExternalResourceTagKeyName ||
+						key == resource.ExternalResourceTagKeyProvider {
+						t.Errorf("Pre-upgrade resource unexpectedly has crossplane label: %s", key)
+					}
+				}
+
+				klog.V(4).Infof("Pre-upgrade label check passed: no crossplane-* labels found on Space %s", spaceName)
+				return ctx
+			},
+		).
+		WithCustomPostUpgradeAssessment(
+			"Verify default crossplane labels after upgrade",
+			func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+				r, err := res.New(cfg.Client().RESTConfig())
+				if err != nil {
+					t.Fatalf("Failed to create resource client: %v", err)
+				}
+
+				err = v1alpha1.SchemeBuilder.AddToScheme(r.GetScheme())
+				if err != nil {
+					t.Fatalf("Failed to add CloudFoundry scheme: %v", err)
+				}
+
+				space := &v1alpha1.Space{}
+				err = r.Get(ctx, spaceName, cfg.Namespace(), space)
+				if err != nil {
+					t.Fatalf("Failed to get Space resource after upgrade: %v", err)
+				}
+
+				labels := space.Status.AtProvider.Labels
+
+				// Verify crossplane-kind
+				expectedKind := "space.cloudfoundry.crossplane.io"
+				if val, ok := labels[resource.ExternalResourceTagKeyKind]; !ok {
+					t.Errorf("Missing %s label after upgrade", resource.ExternalResourceTagKeyKind)
+				} else if val == nil || *val != expectedKind {
+					t.Errorf("Expected %s=%s, got %v", resource.ExternalResourceTagKeyKind, expectedKind, val)
+				}
+
+				// Verify crossplane-name
+				if val, ok := labels[resource.ExternalResourceTagKeyName]; !ok {
+					t.Errorf("Missing %s label after upgrade", resource.ExternalResourceTagKeyName)
+				} else if val == nil || *val != spaceName {
+					t.Errorf("Expected %s=%s, got %v", resource.ExternalResourceTagKeyName, spaceName, val)
+				}
+
+				// Verify crossplane-providerconfig
+				if space.GetProviderConfigReference() != nil {
+					expectedPC := space.GetProviderConfigReference().Name
+					if val, ok := labels[resource.ExternalResourceTagKeyProvider]; !ok {
+						t.Errorf("Missing %s label after upgrade", resource.ExternalResourceTagKeyProvider)
+					} else if val == nil || *val != expectedPC {
+						t.Errorf("Expected %s=%s, got %v", resource.ExternalResourceTagKeyProvider, expectedPC, val)
+					}
+				}
+
+				klog.V(4).Infof("Post-upgrade label check passed: all 3 crossplane-* labels found on Space %s", spaceName)
+				return ctx
+			},
+		)
+
+	testenv.Test(t, upgradeTest.Feature())
+}

--- a/test/upgrade/testdata/customCrs/labels/import/import.yaml
+++ b/test/upgrade/testdata/customCrs/labels/import/import.yaml
@@ -1,0 +1,15 @@
+apiVersion: cloudfoundry.crossplane.io/v1alpha1
+kind: Organization
+metadata:
+  name: upgrade-test-org
+  annotations:
+    crossplane.io/paused: "false"
+spec:
+  managementPolicies:
+    - Observe
+  forProvider:
+    # IMPORTANT: Change this to an org you have access to
+    # Run `cf orgs` to see available organizations
+    name: cf-ci-e2e # TODO: Change this to an existing org name
+  providerConfigRef:
+    name: default

--- a/test/upgrade/testdata/customCrs/labels/space/space.yaml
+++ b/test/upgrade/testdata/customCrs/labels/space/space.yaml
@@ -1,0 +1,13 @@
+apiVersion: cloudfoundry.crossplane.io/v1alpha1
+kind: Space
+metadata:
+  name: upgrade-test-space
+  annotations:
+    crossplane.io/paused: "false"
+spec:
+  forProvider:
+    name: upgrade-test-space
+    orgRef:
+      name: upgrade-test-org
+  providerConfigRef:
+    name: default


### PR DESCRIPTION
## What
- New client-level `IsUpToDate` / `GenerateCreate` / `GenerateUpdate` / `GenerateObservation` tests for Domain, Org, Space (new files)
- Add `TestIsUpToDate_Metadata` to App, Route, SCB, ServiceInstance existing test files
- E2E: `AssertDefaultLabels` and `AssertLabelsAndAnnotations` helpers verify crossplane labels + user metadata
- E2E: Add label/annotation assertions to app, orgspace, services, and SRB tests
- E2E: Add labels and annotations to all CR YAML manifests
- Upgrade test: verify default labels appear on existing Space after provider upgrade
- Fix: deduplicate space fixture names in orgspace e2e CRs

## Coverage
- Nil metadata, label drift/match, annotation drift/match, subset semantics
- Pre-upgrade: no crossplane-* labels; post-upgrade: all 3 present
- Covers all 8 eligible resource types

## Part of
Split from #281 — PR 6 of 6. Depends on [281#3].

**Merge order:** [281#1] → [281#2] → [281#3] → [281#4] → [281#5] → [281#6]