### PR TITLE
Migrate CF secrets to environment secrets

### DIFF
--- a/.github/workflows/upgrade-test.yaml
+++ b/.github/workflows/upgrade-test.yaml
@@ -18,6 +18,7 @@ on:
 jobs:
   upgrade-test:
     runs-on: ubuntu-latest
+    environment: pr-e2e-no-approval
     steps:
       - name: Checkout code
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0


### PR DESCRIPTION
Adds `environment: pr-e2e-no-approval` to the `upgrade-test` job, which was the only workflow accessing `CF_CREDENTIALS` and `CF_ENVIRONMENT` without an environment gate. All other workflows (`e2e_test.yaml`, `pr-e2e.yaml`, `release.yaml`) already ran within a GitHub environment.