### PR TITLE
chore: update e2e test workflow to inherit secrets and allowlist spec…

### DIFF
--- a/.github/workflows/pr-e2e.yaml
+++ b/.github/workflows/pr-e2e.yaml
@@ -26,8 +26,11 @@ jobs:
     with:
       checkout-ref: ${{ github.event.pull_request.head.sha }}
       environment: ${{ github.event_name == 'pull_request_target' && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association) && 'pr-e2e-no-approval' || 'pr-e2e-approval' }}
-    secrets:
-      CF_CREDENTIALS: ${{ secrets.CF_CREDENTIALS }}
-      CF_ENVIRONMENT: ${{ secrets.CF_ENVIRONMENT }}
+    secrets: inherit
+      # The secrets are inherited from the repository, but we need to explicitly allowlist them here. See https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token for details.
+    
+    # secrets:
+      # CF_CREDENTIALS: ${{ secrets.CF_CREDENTIALS }}
+      #CF_ENVIRONMENT: ${{ secrets.CF_ENVIRONMENT }}
       # USER_WHERE_ROLES_GET_ASSIGNED_EMAIL: ${{ secrets.USER_WHERE_ROLES_GET_ASSIGNED_EMAIL }}
       # TECHNICAL_USER_EMAIL: ${{ secrets.TECHNICAL_USER_EMAIL }}


### PR DESCRIPTION
## Problem

All e2e tests were failing after #298 migrated CF secrets to GitHub environment secrets. The root cause was:

```
Failed to create CF client: cannot extract CF credentials: unexpected end of JSON input
```

The `pr-e2e.yaml` caller workflow was passing secrets explicitly:

```yaml
secrets:
  CF_CREDENTIALS: ${{ secrets.CF_CREDENTIALS }}
  CF_ENVIRONMENT: ${{ secrets.CF_ENVIRONMENT }}
```

With reusable workflows, `${{ secrets.X }}` expressions are evaluated in the **caller's context**, before the `environment:` is applied. This means they resolve against repo-level secrets — not the environment secrets set up in #298 — resulting in empty values and the JSON parse failure.

## Fix

Replace the explicit secret passing with `secrets: inherit`, which correctly propagates secrets from the active environment into the called workflow:

```yaml
secrets: inherit
```

No changes to `e2e_test.yaml` are needed — it already declares and consumes the secrets correctly.

## Related

Closes #298 (follow-up fix)