### PR TITLE
fix: add environment to e2e-test and cleanup-e2e jobs

### DIFF
--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -72,6 +72,7 @@ jobs:
   e2e-test:
     runs-on: ubuntu-latest
     needs: prepare-matrix
+    environment: ${{ inputs.environment }}
     strategy:
       fail-fast: false
       matrix:
@@ -108,6 +109,7 @@ jobs:
   cleanup-e2e:
     runs-on: ubuntu-latest
     needs: [prepare-matrix, e2e-test]
+    environment: pr-e2e-no-approval
     if: always() && needs.prepare-matrix.result == 'success' # intentional: workflow cancellation skips cleanup; resources will persist until the next run
     steps:
       - name: checkout repo


### PR DESCRIPTION
`e2e-test` and `cleanup-e2e` jobs were missing `environment:`, causing CF secrets to be empty. `cleanup-e2e` uses `pr-e2e-no-approval` to prevent approval gates from blocking cleanup.