### PR TITLE
ci(e2e): build provider once and reuse across the test matrix

### DIFF
--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -72,6 +72,9 @@ jobs:
           echo "Test names: ${{ steps.set-matrix.outputs.test-names }}"
 
   # Build image + xpkg + CLI tools once; the matrix consumes them as artifacts.
+  # NOTE: after the artifact retention window expires (retention-days below),
+  # "Re-run failed jobs" fails — build won't re-run, so the artifacts it
+  # produced are gone. Use "Re-run all jobs" to rebuild them.
   build:
     runs-on: ubuntu-latest
     needs: prepare-matrix
@@ -114,7 +117,8 @@ jobs:
         with:
           name: provider-image
           path: provider-image.tar
-          retention-days: 1
+          retention-days: 5
+          overwrite: true
           if-no-files-found: error
 
       - name: Upload provider package (xpkg)
@@ -122,7 +126,8 @@ jobs:
         with:
           name: provider-xpkg
           path: _output/xpkg
-          retention-days: 1
+          retention-days: 5
+          overwrite: true
           if-no-files-found: error
 
       - name: Upload CLI tools
@@ -130,7 +135,8 @@ jobs:
         with:
           name: e2e-tools
           path: .cache/tools
-          retention-days: 1
+          retention-days: 5
+          overwrite: true
           if-no-files-found: error
 
   e2e-test:

--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -225,7 +225,7 @@ jobs:
           CF_CREDENTIALS: ${{ secrets.CF_CREDENTIALS }}
           CF_ENVIRONMENT: ${{ secrets.CF_ENVIRONMENT }}
 
-  e2e-test-success:
+  e2e-tests:
     runs-on: ubuntu-latest
     needs:
       - prepare-matrix

--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -52,7 +52,7 @@ jobs:
       test-names: ${{ steps.set-matrix.outputs.test-names }}
     steps:
       - name: checkout repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ inputs.checkout-ref }}
 
@@ -72,7 +72,7 @@ jobs:
           echo "Test names: ${{ steps.set-matrix.outputs.test-names }}"
 
   # Build image + xpkg + CLI tools once; the matrix consumes them as artifacts.
-  # NOTE: after the artifact retention window expires (retention-days below),
+  # NOTE: after the 7-day artifact retention window expires (retention-days below),
   # "Re-run failed jobs" fails — build won't re-run, so the artifacts it
   # produced are gone. Use "Re-run all jobs" to rebuild them.
   build:
@@ -80,13 +80,13 @@ jobs:
     needs: prepare-matrix
     steps:
       - name: checkout repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ inputs.checkout-ref }}
           submodules: true
 
       - name: Set up Go
-        uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: 'go.mod'
 
@@ -113,29 +113,29 @@ jobs:
         run: docker save "${{ env.E2E_PROVIDER_IMAGE }}" -o provider-image.tar
 
       - name: Upload provider image
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: provider-image
           path: provider-image.tar
-          retention-days: 5
+          retention-days: 7
           overwrite: true
           if-no-files-found: error
 
       - name: Upload provider package (xpkg)
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: provider-xpkg
           path: _output/xpkg
-          retention-days: 5
+          retention-days: 7
           overwrite: true
           if-no-files-found: error
 
       - name: Upload CLI tools
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: e2e-tools
           path: .cache/tools
-          retention-days: 5
+          retention-days: 7
           overwrite: true
           if-no-files-found: error
 
@@ -149,18 +149,18 @@ jobs:
         testName: ${{ fromJson(needs.prepare-matrix.outputs.test-names) }}
     steps:
       - name: checkout repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ inputs.checkout-ref }}
           submodules: true
 
       - name: Set up Go
-        uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: 'go.mod'
 
       - name: Download CLI tools
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: e2e-tools
           path: .cache/tools
@@ -170,13 +170,13 @@ jobs:
         run: find .cache/tools -type f -exec chmod +x {} +
 
       - name: Download provider package (xpkg)
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: provider-xpkg
           path: _output/xpkg
 
       - name: Download provider image
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: provider-image
           path: ${{ runner.temp }}/artifacts/provider-image
@@ -188,7 +188,7 @@ jobs:
         run: docker load -i "${{ runner.temp }}/artifacts/provider-image/provider-image.tar"
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
         with:
           version: v3.14.0
 
@@ -208,13 +208,13 @@ jobs:
     if: always() && needs.prepare-matrix.result == 'success' # intentional: workflow cancellation skips cleanup; resources will persist until the next run
     steps:
       - name: checkout repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.base_ref || github.sha }}
           submodules: true
 
       - name: Set up Go
-        uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: 'go.mod'
 

--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -173,10 +173,13 @@ jobs:
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: provider-image
-          path: .
+          path: ${{ runner.temp }}/artifacts/provider-image
+
+      - name: Validate provider image artifact
+        run: test -f "${{ runner.temp }}/artifacts/provider-image/provider-image.tar"
 
       - name: Load provider image
-        run: docker load -i provider-image.tar
+        run: docker load -i "${{ runner.temp }}/artifacts/provider-image/provider-image.tar"
 
       - name: Install Helm
         uses: azure/setup-helm@v4

--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -41,6 +41,8 @@ concurrency:
 
 env:
   BUILD_ID: ${{ github.run_id }}-${{ github.run_attempt }}
+  E2E_BUILD_REGISTRY: e2e
+  E2E_PROVIDER_IMAGE: e2e/provider-cloudfoundry-amd64
 
 jobs:
   prepare-matrix:
@@ -69,9 +71,71 @@ jobs:
         run: |
           echo "Test names: ${{ steps.set-matrix.outputs.test-names }}"
 
-  e2e-test:
+  # Build image + xpkg + CLI tools once; the matrix consumes them as artifacts.
+  build:
     runs-on: ubuntu-latest
     needs: prepare-matrix
+    steps:
+      - name: checkout repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ inputs.checkout-ref }}
+          submodules: true
+
+      - name: Set up Go
+        uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Fetch CLI tools once (up, kind, kubectl)
+        run: |
+          set -euo pipefail
+          vars="$(make --no-print-directory build.vars | grep -E '^(UP|KIND|KUBECTL)=')"
+          eval "$vars"
+          : "${UP:?}" "${KIND:?}" "${KUBECTL:?}"
+          for attempt in 1 2 3 4 5; do
+            if make "$UP" "$KIND" "$KUBECTL"; then break; fi
+            if [ "$attempt" -eq 5 ]; then
+              echo "::error::failed to fetch CLI tools from upstream CDNs after 5 attempts"
+              exit 1
+            fi
+            echo "tool fetch attempt $attempt failed; backing off $((attempt * 15))s..."
+            sleep "$((attempt * 15))"
+          done
+
+      - name: Build provider image and package once
+        run: make build BUILD_REGISTRY=${{ env.E2E_BUILD_REGISTRY }} PLATFORMS=linux_amd64
+
+      - name: Export provider image
+        run: docker save "${{ env.E2E_PROVIDER_IMAGE }}" -o provider-image.tar
+
+      - name: Upload provider image
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: provider-image
+          path: provider-image.tar
+          retention-days: 1
+          if-no-files-found: error
+
+      - name: Upload provider package (xpkg)
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: provider-xpkg
+          path: _output/xpkg
+          retention-days: 1
+          if-no-files-found: error
+
+      - name: Upload CLI tools
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: e2e-tools
+          path: .cache/tools
+          retention-days: 1
+          if-no-files-found: error
+
+  e2e-test:
+    runs-on: ubuntu-latest
+    needs: [prepare-matrix, build]
     environment: ${{ inputs.environment }}
     strategy:
       fail-fast: false
@@ -89,6 +153,31 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
+      - name: Download CLI tools
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: e2e-tools
+          path: .cache/tools
+
+      - name: Restore tool executable bits
+        # upload-artifact drops the +x bit
+        run: find .cache/tools -type f -exec chmod +x {} +
+
+      - name: Download provider package (xpkg)
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: provider-xpkg
+          path: _output/xpkg
+
+      - name: Download provider image
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: provider-image
+          path: .
+
+      - name: Load provider image
+        run: docker load -i provider-image.tar
+
       - name: Install Helm
         uses: azure/setup-helm@v4
         with:
@@ -97,8 +186,8 @@ jobs:
       - name: Install gettext for envsubst
         run: sudo apt-get update && sudo apt-get install -y gettext
 
-      - name: Run build and e2e test
-        run: make test-acceptance testFilter=${{ matrix.testName }}
+      - name: Deploy prebuilt provider and run e2e test
+        run: make test-acceptance ACCEPTANCE_DEPLOY=local-deploy-prebuilt BUILD_REGISTRY=${{ env.E2E_BUILD_REGISTRY }} testFilter=${{ matrix.testName }}
         env:
           CF_CREDENTIALS: ${{ secrets.CF_CREDENTIALS }}
           CF_ENVIRONMENT: ${{ secrets.CF_ENVIRONMENT }}
@@ -131,6 +220,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - prepare-matrix
+      - build
       - e2e-test
     timeout-minutes: 1
     if: always()
@@ -139,6 +229,11 @@ jobs:
         if: |
           needs.prepare-matrix.result == 'failure' ||
           needs.prepare-matrix.result == 'cancelled'
+        run: exit 1
+      - name: Fail for failed build job
+        if: |
+          needs.build.result == 'failure' ||
+          needs.build.result == 'cancelled'
         run: exit 1
       - name: Fail for failed matrix jobs
         if: |

--- a/Makefile
+++ b/Makefile
@@ -180,6 +180,12 @@ local-deploy: build controlplane.up local.xpkg.deploy.provider.$(PROJECT_NAME)
 	@$(KUBECTL) -n upbound-system wait --for=condition=Available deployment --all --timeout=5m
 	@$(OK) running locally built provider
 
+local-deploy-prebuilt: controlplane.up local.xpkg.deploy.provider.$(PROJECT_NAME)
+	@$(INFO) deploying prebuilt provider
+	@$(KUBECTL) wait provider.pkg $(PROJECT_NAME) --for condition=Healthy --timeout 5m
+	@$(KUBECTL) -n upbound-system wait --for=condition=Available deployment --all --timeout=5m
+	@$(OK) running prebuilt provider
+
 e2e: local-deploy uptest
 
 # Updated End to End Testing following BTP Provider
@@ -204,8 +210,10 @@ generate-test-crs:
 	done
 	@$(OK) CRS generated
 
+ACCEPTANCE_DEPLOY ?= local-deploy
+
 .PHONY: test-acceptance
-test-acceptance: local-deploy $(KUBECTL) generate-test-crs
+test-acceptance: $(ACCEPTANCE_DEPLOY) $(KUBECTL) generate-test-crs
 	@# xp-testing puts the provider secret in crossplane-system; local-deploy installs UXP in upbound-system, so the namespace isn't created upstream.
 	@$(KUBECTL) get namespace crossplane-system >/dev/null 2>&1 || $(KUBECTL) create namespace crossplane-system
 	@$(INFO) running integration tests


### PR DESCRIPTION
## Build the provider once, reuse across the e2e matrix

Splits the e2e workflow into a single `build` job that compiles the image, xpkg, and CLI tools, and a matrix of `e2e-test` jobs that consume those as artifacts instead of each rebuilding.

### Problem

Every matrix shard ran `make test-acceptance`, which invoked `local-deploy` and rebuilt the provider from scratch. The image and xpkg were recompiled once per test function, duplicating identical build work across shards. Each rebuild also re-fetched the CLI tools, which exposed a CDN rate-limiting problem that could fail any shard.

### Fix

- New `build` job (gated behind the approval environment via `needs: prepare-matrix`) builds `e2e/provider-cloudfoundry-amd64` + xpkg once with `BUILD_REGISTRY=e2e PLATFORMS=linux_amd64`, fetches `up`/`kind`/`kubectl` with a 5-attempt backoff, and uploads all three as 1-day-retention artifacts (`if-no-files-found: error`).
- `e2e-test` shards download the artifacts, restore the executable bit `upload-artifact` strips, `docker load` the image, and deploy via a new Makefile target instead of building.
- `Makefile`: add `local-deploy-prebuilt`, which deploys the prebuilt package (`controlplane.up` plus `local.xpkg.deploy.provider` plus Healthy/Available waits, no `build`), and route `test-acceptance` through `ACCEPTANCE_DEPLOY ?= local-deploy` so the default path is unchanged and CI overrides it to `local-deploy-prebuilt`.
- `e2e-test-success` now also fails closed on a failed/cancelled `build` job.
