### PR TITLE
fix: remove workflow approval from matrix jobs

### DIFF
--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -1,4 +1,4 @@
-# Run e2e tests in a single CF enviironment, potentially requiring approval based on the `environment` input.
+# Run e2e tests in a single CF environment, potentially requiring approval based on the `environment` input.
 #
 # Enviroment variables/secrets that are needed
 # CF_CREDENTIALS contains the login information of the CF technical user for this test

--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -1,3 +1,5 @@
+# Run e2e tests in a single CF enviironment, potentially requiring approval based on the `environment` input.
+#
 # Enviroment variables/secrets that are needed
 # CF_CREDENTIALS contains the login information of the CF technical user for this test
 # CF_ENVIRONMENT contains the URL of the CF API endpoint
@@ -8,7 +10,6 @@
 name: e2e-Tests
 
 on:
-  workflow_dispatch:
   workflow_call:
     inputs:
       checkout-ref:
@@ -47,7 +48,7 @@ env:
 jobs:
   prepare-matrix:
     runs-on: ubuntu-latest
-    environment: ${{ inputs.environment }}
+    environment: ${{ inputs.environment }} # approval here for the entire workflow, later jobs use no approval environment
     outputs:
       test-names: ${{ steps.set-matrix.outputs.test-names }}
     steps:
@@ -142,7 +143,7 @@ jobs:
   e2e-test:
     runs-on: ubuntu-latest
     needs: [prepare-matrix, build]
-    environment: ${{ inputs.environment }}
+    environment: pr-e2e-no-approval  # approval is on the preceding prepare-matrix job
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pr-e2e.yaml
+++ b/.github/workflows/pr-e2e.yaml
@@ -1,3 +1,5 @@
+# Runs e2e tests on PRs that are not solely markdown changes.
+#
 # The on.pull_request_target runs on changes to a pull request. Contrary to the on.pull_request, this pipeline has access to secrets and can therefore run e2e tests.
 # DANGEROUS: 1) with access to secrets it is possible to steal those by a pull request that executes code that reads the secrets and exfiltrates those.
 # DANGEROUS: 2) the GITHUB_TOKEN has read and write permissions by default. Therefore, restrict the permissions with the permissions field


### PR DESCRIPTION
GHA Workflow: for e2e tests, remove environment approval from matrix job. This spams all approvers for each matrix job. 

Also remove workflow_dispatch since this currently has no "environment" input, and would circumvent the env selection. 