### PR TITLE
ci: shift e2e approval left

### DIFF
--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -1,4 +1,5 @@
-# Run e2e tests in a single CF environment, potentially requiring approval based on the `environment` input.
+# Run e2e tests in a single CF environment. Approval is handled by the caller
+# before invoking this workflow.
 #
 # Enviroment variables/secrets that are needed
 # CF_CREDENTIALS contains the login information of the CF technical user for this test
@@ -17,18 +18,7 @@ on:
         default: ''
         required: false
         type: string
-      environment:
-        description: 'the environment to run in'
-        default: 'pr-e2e-approval'
-        required: false
-        type: string
-    secrets:
-      CF_CREDENTIALS:
-        description: contains the login information of the CF technical user for this test
-        required: true
-      CF_ENVIRONMENT:
-        description: contains the URL of the CF API endpoint
-        required: true
+
 
 permissions:
   contents: read
@@ -48,7 +38,6 @@ env:
 jobs:
   prepare-matrix:
     runs-on: ubuntu-latest
-    environment: ${{ inputs.environment }} # approval here for the entire workflow, later jobs use no approval environment
     outputs:
       test-names: ${{ steps.set-matrix.outputs.test-names }}
     steps:
@@ -143,7 +132,7 @@ jobs:
   e2e-test:
     runs-on: ubuntu-latest
     needs: [prepare-matrix, build]
-    environment: pr-e2e-no-approval  # approval is on the preceding prepare-matrix job
+    environment: pr-e2e-no-approval
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pr-e2e.yaml
+++ b/.github/workflows/pr-e2e.yaml
@@ -23,13 +23,15 @@ permissions:
   contents: read
 
 jobs:
+  approve:
+    runs-on: ubuntu-latest
+    environment: ${{ github.event_name == 'pull_request_target' && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association) && 'pr-e2e-no-approval' || 'pr-e2e-approval' }}
+    steps:
+      - run: echo "Approved"
+
   run-e2e-test:
+    needs: approve
     uses: ./.github/workflows/e2e_test.yaml
     with:
       checkout-ref: ${{ github.event.pull_request.head.sha }}
-      environment: ${{ github.event_name == 'pull_request_target' && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association) && 'pr-e2e-no-approval' || 'pr-e2e-approval' }}
-    secrets:
-      CF_CREDENTIALS: ${{ secrets.CF_CREDENTIALS }}
-      CF_ENVIRONMENT: ${{ secrets.CF_ENVIRONMENT }}
-      # USER_WHERE_ROLES_GET_ASSIGNED_EMAIL: ${{ secrets.USER_WHERE_ROLES_GET_ASSIGNED_EMAIL }}
-      # TECHNICAL_USER_EMAIL: ${{ secrets.TECHNICAL_USER_EMAIL }}
+    secrets: inherit


### PR DESCRIPTION
issue: a workflow waiting for approval is already blocking the concurrency slot for other PRs 

since matrix jobs should run in parallel, can't use job level concurrency, need to keep it at workflow level

shift approval left outside of the workflow

now, e2e workflow always runs on the no-approval environment, so remove parameters