### PR TITLE
feat: bump package metadata to v1 for Crossplane v2 compatibility

### DIFF
--- a/package/crossplane.yaml
+++ b/package/crossplane.yaml
@@ -1,4 +1,4 @@
-apiVersion: meta.pkg.crossplane.io/v1alpha1
+apiVersion: meta.pkg.crossplane.io/v1
 kind: Provider
 metadata:
   name: provider-cloudfoundry


### PR DESCRIPTION
Bumps `package/crossplane.yaml` from `meta.pkg.crossplane.io/v1alpha1` to `meta.pkg.crossplane.io/v1`.

Crossplane v2 deprecates `v1alpha1` package metadata and only recognizes `v1`. This change is required for the provider to be installable on Crossplane v2 clusters.

All other v2 prerequisites are already in place:
- `crossplane-runtime` v1.20.0
- `xp-testing` v1.9.2
- `Delete` returns `(managed.ExternalDelete, error)`
- `Disconnect` method implemented on all external clients
- E2E tests use Crossplane 1.20.1 + `DeploymentRuntimeConfig` (no `ControllerConfig`)
- Single-image build via `imagelight.mk` + `xpkg.build`

This is a non-breaking change for Crossplane v1 (v1 has supported `meta.pkg.crossplane.io/v1` since 1.18+). It enables installation on Crossplane v2 clusters.