### PR TITLE
fix(serviceinstance): skip sharing reconciliation when sharedSpaces is nil

### DIFF
--- a/internal/controller/serviceinstance/controller.go
+++ b/internal/controller/serviceinstance/controller.go
@@ -213,12 +213,14 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 		// Check if the credentials in the spec match the credentials in the external resource
 		upToDate := credentialsUpToDate && serviceinstance.IsUpToDate(&cr.Spec.ForProvider, r)
 
-		// Check if shared spaces are up to date
-		sharedSpacesUpToDate, err := c.serviceinstance.AreSharedSpacesUpToDate(ctx, r.GUID, cr.Spec.ForProvider.SharedSpaces)
-		if err != nil {
-			return managed.ExternalObservation{ResourceExists: true}, errors.Wrap(err, errCheckSharedSpaces)
+		// Check if shared spaces are up to date (only if field is explicitly set)
+		if cr.Spec.ForProvider.SharedSpaces != nil {
+			sharedSpacesUpToDate, err := c.serviceinstance.AreSharedSpacesUpToDate(ctx, r.GUID, cr.Spec.ForProvider.SharedSpaces)
+			if err != nil {
+				return managed.ExternalObservation{ResourceExists: true}, errors.Wrap(err, errCheckSharedSpaces)
+			}
+			upToDate = upToDate && sharedSpacesUpToDate
 		}
-		upToDate = upToDate && sharedSpacesUpToDate
 
 		return managed.ExternalObservation{ResourceExists: true, ResourceUpToDate: upToDate}, nil
 	default:
@@ -315,9 +317,11 @@ func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 		}
 	}
 
-	// Update shared spaces after successful update
-	if err := c.serviceinstance.UpdateSharedSpaces(ctx, *cr.Status.AtProvider.ID, cr.Spec.ForProvider.SharedSpaces); err != nil {
-		return managed.ExternalUpdate{}, errors.Wrap(err, errUpdateSharedSpaces)
+	// Update shared spaces after successful update (only if field is explicitly set)
+	if cr.Spec.ForProvider.SharedSpaces != nil {
+		if err := c.serviceinstance.UpdateSharedSpaces(ctx, *cr.Status.AtProvider.ID, cr.Spec.ForProvider.SharedSpaces); err != nil {
+			return managed.ExternalUpdate{}, errors.Wrap(err, errUpdateSharedSpaces)
+		}
 	}
 
 	return managed.ExternalUpdate{}, nil

--- a/internal/controller/serviceinstance/controller_test.go
+++ b/internal/controller/serviceinstance/controller_test.go
@@ -639,6 +639,39 @@ func TestObserve(t *testing.T) {
 				return m
 			},
 		},
+		"SharedSpacesNilNotManaged": {
+			args: args{
+				mg: serviceInstance("managed",
+					withExternalName(guid),
+					withSpace(spaceGUID),
+					withServicePlan(v1alpha1.ServicePlanParameters{ID: &servicePlan}),
+					// sharedSpaces field is not set/is nil, sharing is unmanaged
+				),
+			},
+			want: want{
+				mg: serviceInstance("managed",
+					withExternalName(guid),
+					withServicePlan(v1alpha1.ServicePlanParameters{ID: &servicePlan}),
+					withStatus(v1alpha1.ServiceInstanceObservation{ID: &guid, ServicePlan: &servicePlan}),
+					withConditions(xpv1.Available()),
+				),
+				obs: managed.ExternalObservation{ResourceExists: true, ResourceUpToDate: true},
+				err: nil,
+			},
+			service: func() *fake.MockServiceInstance {
+				m := &fake.MockServiceInstance{}
+				m.On("Get", guid).Return(
+					&fake.NewServiceInstance("managed").SetName(name).SetGUID(guid).SetServicePlan(servicePlan).SetLastOperation(v1alpha1.LastOperationCreate, v1alpha1.LastOperationSucceeded).ServiceInstance,
+					nil,
+				)
+				m.On("GetManagedParameters", guid).Return(
+					fake.JSONRawMessage(""),
+					nil,
+				)
+				// GetSharedSpaceRelationships must NOT be called
+				return m
+			},
+		},
 		"GetSharedSpaceRelationshipsError": {
 			args: args{
 				mg: serviceInstance("managed",
@@ -1275,6 +1308,7 @@ func TestUpdate(t *testing.T) {
 					withServicePlan(v1alpha1.ServicePlanParameters{ID: &servicePlan}),
 					withExternalName(guid),
 					withStatus(v1alpha1.ServiceInstanceObservation{ID: &guid}),
+					withSharedSpaces(), // sharedSpaces field explicitly set empty, unshare all
 				),
 			},
 			want: want{
@@ -1283,6 +1317,7 @@ func TestUpdate(t *testing.T) {
 					withServicePlan(v1alpha1.ServicePlanParameters{ID: &servicePlan}),
 					withExternalName(guid),
 					withStatus(v1alpha1.ServiceInstanceObservation{ID: &guid}),
+					withSharedSpaces(),
 				),
 				obs: managed.ExternalUpdate{},
 				err: nil,
@@ -1365,13 +1400,14 @@ func TestUpdate(t *testing.T) {
 				return m
 			},
 		},
-		"UnShareWithSpacesError": {
+		"SharedSpacesNilNotManaged": {
 			args: args{
 				mg: serviceInstance("managed",
 					withSpace(spaceGUID),
 					withServicePlan(v1alpha1.ServicePlanParameters{ID: &servicePlan}),
 					withExternalName(guid),
 					withStatus(v1alpha1.ServiceInstanceObservation{ID: &guid}),
+					// sharedSpaces field is not set/is nil, sharing is unmanaged
 				),
 			},
 			want: want{
@@ -1380,6 +1416,44 @@ func TestUpdate(t *testing.T) {
 					withServicePlan(v1alpha1.ServicePlanParameters{ID: &servicePlan}),
 					withExternalName(guid),
 					withStatus(v1alpha1.ServiceInstanceObservation{ID: &guid}),
+				),
+				obs: managed.ExternalUpdate{},
+				err: nil,
+			},
+			service: func() *fake.MockServiceInstance {
+				m := &fake.MockServiceInstance{}
+				m.On("UpdateManaged", guid).Return("JOB123", nil)
+				m.On("Get", guid).Return(
+					&fake.NewServiceInstance("managed").SetName(name).SetGUID(guid).SetServicePlan(servicePlan).ServiceInstance,
+					nil,
+				)
+				m.On("GetManagedParameters", guid).Return(nil, nil)
+				// GetSharedSpaceRelationships must NOT be called
+				return m
+			},
+			job: func() *fake.MockJob {
+				m := &fake.MockJob{}
+				m.On("PollComplete").Return(nil)
+				return m
+			},
+		},
+		"UnShareWithSpacesError": {
+			args: args{
+				mg: serviceInstance("managed",
+					withSpace(spaceGUID),
+					withServicePlan(v1alpha1.ServicePlanParameters{ID: &servicePlan}),
+					withExternalName(guid),
+					withStatus(v1alpha1.ServiceInstanceObservation{ID: &guid}),
+					withSharedSpaces(), // explicitly empty: manage sharing, remove all
+				),
+			},
+			want: want{
+				mg: serviceInstance("managed",
+					withSpace(spaceGUID),
+					withServicePlan(v1alpha1.ServicePlanParameters{ID: &servicePlan}),
+					withExternalName(guid),
+					withStatus(v1alpha1.ServiceInstanceObservation{ID: &guid}),
+					withSharedSpaces(),
 				),
 				obs: managed.ExternalUpdate{},
 				err: errors.New("cannot update shared spaces: cannot unshare service instance from spaces: boom"),


### PR DESCRIPTION
Fix that managed service instances are unshared when `sharedSpaces` is not set when upgrading the provider version.