### PR TITLE
fix(servicecredentialbinding): handle job polling errors and capture …

### DIFF
--- a/internal/clients/servicecredentialbinding/servicecredentialbinding.go
+++ b/internal/clients/servicecredentialbinding/servicecredentialbinding.go
@@ -77,8 +77,15 @@ func Create(ctx context.Context, scbClient ServiceCredentialBinding, forProvider
 	}
 
 	if jobGUID != "" { // async creation waits for the job to complete
-		if err := job.PollJobComplete(ctx, scbClient, jobGUID); err != nil {
-			return nil, err
+		if pollErr := job.PollJobComplete(ctx, scbClient, jobGUID); pollErr != nil {
+			// Capture the external name even on error - otherwise a failed create
+			// is invisible to Observe(), which creates another binding instead of
+			// recognizing the existing one, repeating until the circuit breaker
+			// trips and quota may be exhausted.
+			if found, lookupErr := scbClient.Single(ctx, createToListOptions(opt)); lookupErr == nil {
+				return found, pollErr
+			}
+			return nil, pollErr
 		}
 	}
 

--- a/internal/clients/servicecredentialbinding/servicecredentialbinding.go
+++ b/internal/clients/servicecredentialbinding/servicecredentialbinding.go
@@ -193,7 +193,6 @@ func newCreateOption(forProvider v1alpha1.ServiceCredentialBindingParameters, pa
 }
 
 func createToListOptions(create *resource.ServiceCredentialBindingCreate) *client.ServiceCredentialBindingListOptions {
-	// create options are not used in the controller, but can be used in tests
 	opts := client.NewServiceCredentialBindingListOptions()
 	opts.Type.EqualTo(create.Type)
 

--- a/internal/controller/servicecredentialbinding/controller.go
+++ b/internal/controller/servicecredentialbinding/controller.go
@@ -204,7 +204,11 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 
 	serviceBinding, err := scb.Create(ctx, c.scbClient, cr.Spec.ForProvider, params)
 	if serviceBinding != nil && serviceBinding.GUID != "" {
-		// Capture the external name even if the job failed, as the binding was created in Cloud Foundry and we can manage it going forward. This can happen when CF accepts the request but the broker fails to provision the backing service instance (e.g. due to invalid parameters).
+		// Capture the external name even if the job failed,
+		// as the binding was created in Cloud Foundry and we can manage it going forward.
+		// This can happen when CF accepts the request
+		// but the broker fails to provision the backing service instance
+		// (e.g. due to invalid parameters).
 		meta.SetExternalName(cr, serviceBinding.GUID)
 	}
 	if err != nil {

--- a/internal/controller/servicecredentialbinding/controller.go
+++ b/internal/controller/servicecredentialbinding/controller.go
@@ -203,11 +203,13 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 	}
 
 	serviceBinding, err := scb.Create(ctx, c.scbClient, cr.Spec.ForProvider, params)
+	if serviceBinding != nil && serviceBinding.GUID != "" {
+		// Capture the external name even if the job failed, as the binding was created in Cloud Foundry and we can manage it going forward. This can happen when CF accepts the request but the broker fails to provision the backing service instance (e.g. due to invalid parameters).
+		meta.SetExternalName(cr, serviceBinding.GUID)
+	}
 	if err != nil {
 		return managed.ExternalCreation{}, fmt.Errorf(errCreate, err)
 	}
-
-	meta.SetExternalName(cr, serviceBinding.GUID)
 
 	if cr.Annotations != nil {
 		if _, ok := cr.Annotations[scb.ForceRotationKey]; ok {

--- a/internal/controller/servicecredentialbinding/controller_test.go
+++ b/internal/controller/servicecredentialbinding/controller_test.go
@@ -881,6 +881,7 @@ func TestCreate(t *testing.T) {
 					"key",
 					withServiceInstanceID(serviceInstanceGUID),
 					withCreateAttempts(1),
+					withExternalName(guid),
 				),
 				obs: managed.ExternalCreation{},
 				err: fmt.Errorf(errCreate, errCFClientError),
@@ -903,6 +904,37 @@ func TestCreate(t *testing.T) {
 				return m
 			},
 		},
+		"PollErrorBindingNotFound": {
+			args: args{
+				mg: serviceCredentialBinding("key", withServiceInstanceID(serviceInstanceGUID)),
+			},
+			want: want{
+				mg: serviceCredentialBinding(
+					"key",
+					withServiceInstanceID(serviceInstanceGUID),
+					withCreateAttempts(1),
+				),
+				obs: managed.ExternalCreation{},
+				err: fmt.Errorf(errCreate, errCFClientError),
+			},
+			service: func() *fake.MockServiceCredentialBinding {
+				m := &fake.MockServiceCredentialBinding{}
+
+				m.On("Create", mock.Anything, mock.Anything).Return(
+					guid,
+					scbKey(),
+					nil,
+				)
+
+				m.On("Single", mock.Anything, mock.Anything).Return(
+					fake.ServiceCredentialBindingNil,
+					fake.ErrNoResultReturned,
+				)
+				m.On("PollComplete", mock.Anything, mock.Anything, mock.Anything).Return(errCFClientError)
+
+				return m
+			},
+		},
 		"AlreadyExist": {
 			args: args{
 				mg: serviceCredentialBinding("key", withServiceInstanceID(serviceInstanceGUID)),
@@ -912,6 +944,7 @@ func TestCreate(t *testing.T) {
 					"key",
 					withServiceInstanceID(serviceInstanceGUID),
 					withCreateAttempts(1),
+					withExternalName(guid),
 				),
 
 				obs: managed.ExternalCreation{},


### PR DESCRIPTION
fix(servicecredentialbinding): capture external-name when async create job fails

## What was happening
When a ServiceCredentialBinding's async creation job failed (e.g. broker rejects an invalid parameter), the binding was still created in CF but its GUID was discarded. With no external-name set, the next reconcile couldn't find it - the name-search fallback also failed, since it searches the unrandomized spec name while CF has the randomized one. Each reconcile looked like "nothing exists," triggering another Create() and repeating until the circuit breaker tripped at 5 attempts - orphaning several bindings and risking quota exhaustion.

## Fix
Recover the binding's GUID via a name-based lookup when the job poll fails, and set external-name even when Create() returns an error. crossplane-runtime persists annotation changes on the create-error path specifically for this (UpdateCriticalAnnotations)

## Result
A failed create now stops after one attempt - Observe()'s existing LastOperationFailed handling marks the resource Unavailable with the broker's actual error, instead of retrying up to 5 times.

