### PR TITLE
fix(app): update docker image to nginx-unprivileged for consistency

### DIFF
--- a/test/e2e/crs/app/app.yaml
+++ b/test/e2e/crs/app/app.yaml
@@ -12,7 +12,7 @@ spec:
         resolve: Always
     lifecycle: docker
     docker:
-      image: loud/hello_co:latest
+      image: ghcr.io/nginxinc/nginx-unprivileged:latest
     processes:
       - type: web
         health-check-type: http
@@ -38,7 +38,7 @@ spec:
         resolve: Always
     lifecycle: docker
     docker:
-      image: loud/hello_co:latest
+      image: ghcr.io/nginxinc/nginx-unprivileged:latest
     processes:
       - type: web
         health-check-type: http


### PR DESCRIPTION
## Problem

The App e2e test (`TestCloudfoundry_App`) is consistently failing across PRs with:

Failed getting docker image manifest by tag: `reading manifest latest in registry-1.docker.io/loud/hello_co: toomanyrequests: You have reached your unauthenticated pull rate limit`.

The test uses `loud/hello_co:latest` from Docker Hub. The image pull happens on CF's own staging infrastructure (diego), not the CI runner — meaning the rate limit is tied to the CF landscape's stable egress IP, shared across all workloads on that foundation pulling from Docker Hub unauthenticated. Waiting for the limit to reset is not a reliable fix
since the IP is continuously active.

## Fix

Replace `loud/hello_co:latest` with `ghcr.io/nginxinc/nginx-unprivileged:latest` in `test/e2e/crs/app/app.yaml`. This image is public on GitHub Container Registry (no rate limits, no auth needed), runs as non-root (required by CF),
and serves HTTP 200 on `/` on port 8080 — satisfying the existing health check and process config without any other changes.
