### PR TITLE
docs: add CRD browser link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 `crossplane-provider-cloudfoundry` lets you define Cloud Foundry resources (Orgs, Spaces, Services, Applications, and more) as Kubernetes custom resources. Crossplane takes care of the rest: provisioning, drift detection, and reconciliation — no scripts, no manual clicks.
 
+All available CRDs can be found in the [API reference](https://doc.crds.dev/github.com/SAP/crossplane-provider-cloudfoundry).
+
 ---
 
 ## 🌍 Community


### PR DESCRIPTION
## Summary

- Adds a link to the [doc.crds.dev API reference](https://doc.crds.dev/github.com/SAP/crossplane-provider-cloudfoundry) in the README, matching the same pattern already used in `crossplane-provider-btp`.

## Test plan

- [ ] Verify the link resolves correctly once the provider is indexed on doc.crds.dev