### PR TITLE
Fix skip logic

### DIFF
--- a/.github/workflows/detect-non-doc-changes.yaml
+++ b/.github/workflows/detect-non-doc-changes.yaml
@@ -3,9 +3,9 @@ name: Detect Non-Doc Changes
 on:
   workflow_call:
     outputs:
-      has-non-doc-changes:
-        description: "'true' if the PR contains changes outside md/mdx files"
-        value: ${{ jobs.detect-non-doc-changes.outputs.has-non-doc-changes }}
+      has-only-doc-changes:
+        description: "'true' if the PR contains only md/mdx changes"
+        value: ${{ jobs.detect-non-doc-changes.outputs.has-only-doc-changes }}
 
 permissions:
   contents: read
@@ -14,7 +14,7 @@ jobs:
   detect-non-doc-changes:
     runs-on: ubuntu-latest
     outputs:
-      has-non-doc-changes: ${{ steps.check.outputs.has-non-doc-changes }}
+      has-only-doc-changes: ${{ steps.check.outputs.has-only-doc-changes }}
 
     steps:
       - id: check
@@ -25,9 +25,9 @@ jobs:
           echo "Changed files:"
           echo "$FILES"
           if echo "$FILES" | grep -qvE '\.(md|mdx)$'; then
-            echo "has-non-doc-changes=true" >> "$GITHUB_OUTPUT"
+            echo "has-only-doc-changes=false" >> "$GITHUB_OUTPUT"
             echo "PR contains non-doc changes — running full checks"
           else
-            echo "has-non-doc-changes=false" >> "$GITHUB_OUTPUT"
+            echo "has-only-doc-changes=true" >> "$GITHUB_OUTPUT"
             echo "PR contains only doc changes (md/mdx) — skipping non-doc checks"
           fi

--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -230,24 +230,21 @@ jobs:
       - build
       - e2e-test
     timeout-minutes: 1
-    if: always()
+    if: always() && !inputs.skip
     steps:
       - name: Fail for failed prepare-matrix job
         if: |
-          !inputs.skip && (
           needs.prepare-matrix.result == 'failure' ||
-          needs.prepare-matrix.result == 'cancelled')
+          needs.prepare-matrix.result == 'cancelled'
         run: exit 1
       - name: Fail for failed build job
         if: |
-          !inputs.skip && (
           needs.build.result == 'failure' ||
-          needs.build.result == 'cancelled')
+          needs.build.result == 'cancelled'
         run: exit 1
       - name: Fail for failed matrix jobs
         if: |
-          !inputs.skip && (
           needs.e2e-test.result == 'failure' ||
           needs.e2e-test.result == 'cancelled' ||
-          needs.e2e-test.result == 'skipped')
+          needs.e2e-test.result == 'skipped'
         run: exit 1

--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -72,7 +72,6 @@ jobs:
   # "Re-run failed jobs" fails — build won't re-run, so the artifacts it
   # produced are gone. Use "Re-run all jobs" to rebuild them.
   build:
-    if: ${{ !inputs.skip }}
     runs-on: ubuntu-latest
     needs: prepare-matrix
     steps:
@@ -137,7 +136,6 @@ jobs:
           if-no-files-found: error
 
   e2e-test:
-    if: ${{ !inputs.skip }}
     runs-on: ubuntu-latest
     needs: [prepare-matrix, build]
     environment: pr-e2e-no-approval

--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -18,6 +18,11 @@ on:
         default: ''
         required: false
         type: string
+      skip:
+        description: 'skip all jobs (e.g. doc-only changes); workflow still runs for branch protection'
+        default: false
+        required: false
+        type: boolean
 
 
 permissions:
@@ -37,6 +42,7 @@ env:
 
 jobs:
   prepare-matrix:
+    if: ${{ !inputs.skip }}
     runs-on: ubuntu-latest
     outputs:
       test-names: ${{ steps.set-matrix.outputs.test-names }}
@@ -66,6 +72,7 @@ jobs:
   # "Re-run failed jobs" fails — build won't re-run, so the artifacts it
   # produced are gone. Use "Re-run all jobs" to rebuild them.
   build:
+    if: ${{ !inputs.skip }}
     runs-on: ubuntu-latest
     needs: prepare-matrix
     steps:
@@ -130,6 +137,7 @@ jobs:
           if-no-files-found: error
 
   e2e-test:
+    if: ${{ !inputs.skip }}
     runs-on: ubuntu-latest
     needs: [prepare-matrix, build]
     environment: pr-e2e-no-approval
@@ -195,7 +203,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [prepare-matrix, e2e-test]
     environment: pr-e2e-no-approval
-    if: always() && needs.prepare-matrix.result == 'success' # intentional: workflow cancellation skips cleanup; resources will persist until the next run
+    if: always() && !inputs.skip && needs.prepare-matrix.result == 'success' # intentional: workflow cancellation skips cleanup; resources will persist until the next run
     steps:
       - name: checkout repo
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -226,17 +234,20 @@ jobs:
     steps:
       - name: Fail for failed prepare-matrix job
         if: |
+          !inputs.skip && (
           needs.prepare-matrix.result == 'failure' ||
-          needs.prepare-matrix.result == 'cancelled'
+          needs.prepare-matrix.result == 'cancelled')
         run: exit 1
       - name: Fail for failed build job
         if: |
+          !inputs.skip && (
           needs.build.result == 'failure' ||
-          needs.build.result == 'cancelled'
+          needs.build.result == 'cancelled')
         run: exit 1
       - name: Fail for failed matrix jobs
         if: |
+          !inputs.skip && (
           needs.e2e-test.result == 'failure' ||
           needs.e2e-test.result == 'cancelled' ||
-          needs.e2e-test.result == 'skipped'
+          needs.e2e-test.result == 'skipped')
         run: exit 1

--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -19,7 +19,7 @@ on:
         required: false
         type: string
       skip:
-        description: 'skip all jobs (e.g. doc-only changes); workflow still runs for branch protection'
+        description: 'skip all jobs (e.g. for doc-only changes); workflow still runs to satisfy branch protection'
         default: false
         required: false
         type: boolean

--- a/.github/workflows/pr-e2e.yaml
+++ b/.github/workflows/pr-e2e.yaml
@@ -44,7 +44,7 @@ jobs:
 
   approve:
     needs: [detect-non-doc-changes, get-author-association]
-    if: needs.detect-non-doc-changes.outputs.has-non-doc-changes == 'true'
+    if: needs.detect-non-doc-changes.outputs.has-only-doc-changes != 'true'
     runs-on: ubuntu-latest
     environment:
       name: ${{ needs.get-author-association.outputs.is-collaborator == 'true' && 'pr-e2e-no-approval' || 'pr-e2e-approval' }}
@@ -57,5 +57,5 @@ jobs:
     uses: ./.github/workflows/e2e_test.yaml
     with:
       checkout-ref: ${{ github.event.pull_request.head.sha }}
-      skip: ${{ needs.detect-non-doc-changes.outputs.has-non-doc-changes != 'true' }}
+      skip: ${{ needs.detect-non-doc-changes.outputs.has-only-doc-changes == 'true' }}
     secrets: inherit

--- a/.github/workflows/pr-e2e.yaml
+++ b/.github/workflows/pr-e2e.yaml
@@ -25,29 +25,13 @@ jobs:
 
   # see https://github.blog/changelog/2025-08-08-upcoming-changes-to-github-events-api-payloads/#whats-changing
   # for deprecation of event.pull_request.author_association
-  # using this endpoint which returns 204 or 404 because it is available with the token's read permissions
-  # https://docs.github.com/en/rest/collaborators/collaborators?apiVersion=2026-03-10#check-if-a-user-is-a-repository-collaborator
-  get-author-association:
-    runs-on: ubuntu-latest
-    outputs:
-      is-collaborator: ${{ steps.check.outputs.is-collaborator }}
-    steps:
-      - id: check
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          if gh api repos/${{ github.repository }}/collaborators/${{ github.event.pull_request.user.login }} --silent 2>/dev/null; then
-            echo "is-collaborator=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "is-collaborator=false" >> "$GITHUB_OUTPUT"
-          fi
-
+  # keeping it for now since the alternatice requires a PAT based approach
   approve:
-    needs: [detect-non-doc-changes, get-author-association]
+    needs: [detect-non-doc-changes]
     if: needs.detect-non-doc-changes.outputs.has-only-doc-changes != 'true'
     runs-on: ubuntu-latest
     environment:
-      name: ${{ needs.get-author-association.outputs.is-collaborator == 'true' && 'pr-e2e-no-approval' || 'pr-e2e-approval' }}
+      name: ${{ (github.event.pull_request.author_association == 'OWNER' || github.event.pull_request.author_association == 'MEMBER' || github.event.pull_request.author_association == 'COLLABORATOR') && 'pr-e2e-no-approval' || 'pr-e2e-approval' }}
     steps:
       - run: echo "Approved"
 

--- a/.github/workflows/pr-e2e.yaml
+++ b/.github/workflows/pr-e2e.yaml
@@ -52,9 +52,10 @@ jobs:
       - run: echo "Approved"
 
   run-e2e-test:
-    needs: approve
-    if: needs.approve.result == 'success'
+    needs: [approve, detect-non-doc-changes]
+    if: needs.approve.result == 'success' || needs.approve.result == 'skipped'
     uses: ./.github/workflows/e2e_test.yaml
     with:
       checkout-ref: ${{ github.event.pull_request.head.sha }}
+      skip: ${{ needs.detect-non-doc-changes.outputs.has-non-doc-changes != 'true' }}
     secrets: inherit

--- a/.github/workflows/pr-e2e.yaml
+++ b/.github/workflows/pr-e2e.yaml
@@ -28,7 +28,7 @@ jobs:
   # using this endpoint which returns 204 or 404 because it is available with the token's read permissions
   # https://docs.github.com/en/rest/collaborators/collaborators?apiVersion=2026-03-10#check-if-a-user-is-a-repository-collaborator
   get-author-association:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     outputs:
       is-collaborator: ${{ steps.check.outputs.is-collaborator }}
     steps:

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -25,10 +25,10 @@ jobs:
 
   run-unit-test:
     needs: detect-non-doc-changes
-    if: needs.detect-non-doc-changes.outputs.has-non-doc-changes == 'true'
+    if: needs.detect-non-doc-changes.outputs.has-only-doc-changes != 'true'
     uses: ./.github/workflows/unit_test.yaml
 
   run-make-reviewable-and-check-diff:
     needs: detect-non-doc-changes
-    if: needs.detect-non-doc-changes.outputs.has-non-doc-changes == 'true'
+    if: needs.detect-non-doc-changes.outputs.has-only-doc-changes != 'true'
     uses: ./.github/workflows/reviewable_check_diff.yaml


### PR DESCRIPTION
Fix erroneous skipping logic for e2e tests. 

Unfortunately, the job level skipping does not work if the job calls another workflow. So we need to pass an input to the e2e tests and skip the individual jobs in there, in order to satisfy the branch protection rule. 

Also, switch the collaborators logic back to the previous version, sind the collaborators API is not accessible without a PAT. 