### PR TITLE
ci: fix skip logic part 2

### DIFF
--- a/.github/workflows/pr-e2e.yaml
+++ b/.github/workflows/pr-e2e.yaml
@@ -37,7 +37,7 @@ jobs:
 
   run-e2e-test:
     needs: [approve, detect-non-doc-changes]
-    if: needs.approve.result == 'success' || needs.approve.result == 'skipped'
+    if: always() && (needs.approve.result == 'success' || needs.approve.result == 'skipped')
     uses: ./.github/workflows/e2e_test.yaml
     with:
       checkout-ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -25,10 +25,12 @@ jobs:
 
   run-unit-test:
     needs: detect-non-doc-changes
-    if: needs.detect-non-doc-changes.outputs.has-only-doc-changes != 'true'
     uses: ./.github/workflows/unit_test.yaml
+    with:
+      skip: ${{ needs.detect-non-doc-changes.outputs.has-only-doc-changes == 'true' }}
 
   run-make-reviewable-and-check-diff:
     needs: detect-non-doc-changes
-    if: needs.detect-non-doc-changes.outputs.has-only-doc-changes != 'true'
     uses: ./.github/workflows/reviewable_check_diff.yaml
+    with:
+      skip: ${{ needs.detect-non-doc-changes.outputs.has-only-doc-changes == 'true' }}

--- a/.github/workflows/reviewable_check_diff.yaml
+++ b/.github/workflows/reviewable_check_diff.yaml
@@ -5,6 +5,12 @@ name: Reviewable&Check-Diff
 on:
   workflow_dispatch:
   workflow_call:
+    inputs:
+      skip:
+        description: 'skip all jobs (e.g. for doc-only changes); workflow still runs to satisfy branch protection'
+        default: false
+        required: false
+        type: boolean
 
 permissions:
   contents: read
@@ -14,6 +20,7 @@ env:
 
 jobs:
   reviewable-checkdiff:
+    if: ${{ inputs.skip != 'true' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/.github/workflows/reviewable_check_diff.yaml
+++ b/.github/workflows/reviewable_check_diff.yaml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   reviewable-checkdiff:
-    if: ${{ inputs.skip != 'true' }}
+    if: ${{ !inputs.skip }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -6,6 +6,12 @@ name: Unit-Tests
 on:
   workflow_dispatch:
   workflow_call:
+    inputs:
+      skip:
+        description: 'skip all jobs (e.g. for doc-only changes); workflow still runs to satisfy branch protection'
+        default: false
+        required: false
+        type: boolean
 
 permissions:
   contents: read
@@ -13,6 +19,7 @@ permissions:
 jobs:
 
   unit-tests:
+    if: ${{ inputs.skip != 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -19,7 +19,7 @@ permissions:
 jobs:
 
   unit-tests:
-    if: ${{ inputs.skip != 'true' }}
+    if: ${{ !inputs.skip }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7


### PR DESCRIPTION
followup to https://github.com/SAP/crossplane-provider-cloudfoundry/pull/325

Add the job level skipping with workflow inputs to the other two test workflows as well 

Fix the e2e running with the needed "always" to stop GHA from short circuiting and not checking the if condition at all on previous skip 