### PR TITLE
fix(upgrade): support single-image provider layouts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,20 @@ UPTEST_VERSION = v0.11.1
 IMAGES = provider-cloudfoundry
 -include build/makelib/imagelight.mk
 
+# Local upgrade tests use the built Crossplane package, not the provider
+# runtime image. The package contains the controller in the single-image
+# layout, so UUT_IMAGES intentionally has no controller key.
+export UUT_CONFIG = $(BUILD_REGISTRY)/provider-cloudfoundry-$(ARCH):latest
+export UUT_XPKG = $(BUILD_REGISTRY)/provider-cloudfoundry-xpkg:latest
+export UUT_IMAGES = {"crossplane/provider-cloudfoundry":"$(UUT_XPKG)"}
+
+.PHONY: local-build
+local-build: build
+	@$(INFO) "Loading xpkg into docker as $(UUT_XPKG)"
+	@XPKG_FILE=$(XPKG_OUTPUT_DIR)/$(PLATFORM)/provider-cloudfoundry-$(VERSION).xpkg && \
+	XPKG_SHA=$$(docker load -i $$XPKG_FILE | sed -n 's/.*ID: //p') && \
+	docker tag $$XPKG_SHA $(UUT_XPKG)
+	@$(OK) "Built local package image: $(UUT_XPKG)"
 
 # Import upgrade test environment variables from shell
 export UPGRADE_TEST_FROM_TAG
@@ -274,8 +288,8 @@ check-upgrade-test-vars: ## Verify required upgrade test environment variables
 build-upgrade-test-images: ## Build local images if testing with 'local' tag
 	@if [ "$(UPGRADE_TEST_FROM_TAG)" == "local" ] || [ "$(UPGRADE_TEST_TO_TAG)" == "local" ]; then \
 		$(INFO) "Building local images (UPGRADE_TEST_FROM_TAG or UPGRADE_TEST_TO_TAG is \"local\")"; \
-		$(MAKE) build; \
-		$(OK) "Built local images: $(UUT_IMAGES)"; \
+		$(MAKE) local-build; \
+		$(OK) "Built local package image: $(UUT_IMAGES)"; \
 	fi
 
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.9
 
 require (
 	github.com/SAP/xp-clifford v0.0.0-20260528123824-27644fae68e8
+	github.com/blang/semver/v4 v4.0.0
 	github.com/cloudfoundry/go-cfclient/v3 v3.0.0-alpha.12
 	github.com/crossplane-contrib/xp-testing v1.9.2
 	github.com/crossplane/crossplane-runtime/v2 v2.2.2
@@ -30,7 +31,6 @@ require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
-	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/catppuccin/go v0.3.0 // indirect
 	github.com/charmbracelet/bubbles v0.21.1-0.20250623103423-23b8fd6302d7 // indirect
 	github.com/charmbracelet/bubbletea v1.3.6 // indirect

--- a/test/test_utils.go
+++ b/test/test_utils.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strings"
 
 	"github.com/crossplane-contrib/xp-testing/pkg/envvar"
 	"github.com/crossplane-contrib/xp-testing/pkg/logging"
@@ -116,20 +117,42 @@ func ApplySecretInCrossplaneNamespace(name string, data map[string]string) env.F
 	)
 }
 
-func GetImagesFromJsonOrPanic(imagesJson string) (string, string) {
-
+// ParseImagesFromJSON validates the UUT_IMAGES mapping and returns the required
+// package image and the optional controller image. A missing controller key is
+// represented by nil; a supplied empty controller value is invalid.
+func ParseImagesFromJSON(imagesJSON string) (string, *string, error) {
 	imageMap := map[string]string{}
-
-	err := json.Unmarshal([]byte(imagesJson), &imageMap)
-
-	if err != nil {
-		panic(errors.Wrap(err, "failed to unmarshal json from UUT_IMAGE"))
+	if err := json.Unmarshal([]byte(imagesJSON), &imageMap); err != nil {
+		return "", nil, fmt.Errorf("failed to unmarshal JSON from %s: %w", UUT_IMAGES_KEY, err)
 	}
 
-	uutConfig := imageMap[UUT_CONFIG_KEY]
-	uutController := imageMap[UUT_CONTROLLER_KEY]
+	packageImage, ok := imageMap[UUT_CONFIG_KEY]
+	if !ok || strings.TrimSpace(packageImage) == "" {
+		return "", nil, fmt.Errorf("%s must contain a non-empty %q value", UUT_IMAGES_KEY, UUT_CONFIG_KEY)
+	}
+	packageImage = strings.TrimSpace(packageImage)
 
-	return uutConfig, uutController
+	controllerImage, ok := imageMap[UUT_CONTROLLER_KEY]
+	if !ok {
+		return packageImage, nil, nil
+	}
+	if strings.TrimSpace(controllerImage) == "" {
+		return "", nil, fmt.Errorf("%s contains an empty %q value", UUT_IMAGES_KEY, UUT_CONTROLLER_KEY)
+	}
+	controllerImage = strings.TrimSpace(controllerImage)
+
+	return packageImage, &controllerImage, nil
+}
+
+// GetImagesFromJsonOrPanic retrieves and validates the package and optional
+// controller images from UUT_IMAGES.
+func GetImagesFromJsonOrPanic(imagesJSON string) (string, *string) {
+	packageImage, controllerImage, err := ParseImagesFromJSON(imagesJSON)
+	if err != nil {
+		panic(errors.Wrap(err, "invalid UUT_IMAGES"))
+	}
+
+	return packageImage, controllerImage
 }
 
 func DeleteResourcesFromDirsGracefully(ctx context.Context, cfg *envconf.Config, resourceDirs []string, timeout wait.Option) error {

--- a/test/test_utils_test.go
+++ b/test/test_utils_test.go
@@ -1,0 +1,67 @@
+package test
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseImagesFromJSON(t *testing.T) {
+	controller := "registry.example/controller:v1.2.0"
+
+	tests := map[string]struct {
+		input              string
+		wantPackage        string
+		wantController     *string
+		wantErrorSubstring string
+	}{
+		"single image": {
+			input:       `{"crossplane/provider-cloudfoundry":"registry.example/provider:v1.3.0"}`,
+			wantPackage: "registry.example/provider:v1.3.0",
+		},
+		"two images": {
+			input:          `{"crossplane/provider-cloudfoundry":"registry.example/provider:v1.2.0","crossplane/provider-cloudfoundry-controller":"registry.example/controller:v1.2.0"}`,
+			wantPackage:    "registry.example/provider:v1.2.0",
+			wantController: &controller,
+		},
+		"malformed JSON": {
+			input:              `{`,
+			wantErrorSubstring: "failed to unmarshal JSON",
+		},
+		"missing package": {
+			input:              `{}`,
+			wantErrorSubstring: "non-empty",
+		},
+		"blank package": {
+			input:              `{"crossplane/provider-cloudfoundry":"   "}`,
+			wantErrorSubstring: "non-empty",
+		},
+		"blank supplied controller": {
+			input:              `{"crossplane/provider-cloudfoundry":"registry.example/provider:v1.2.0","crossplane/provider-cloudfoundry-controller":" "}`,
+			wantErrorSubstring: "empty",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			gotPackage, gotController, err := ParseImagesFromJSON(tt.input)
+			if tt.wantErrorSubstring != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErrorSubstring) {
+					t.Fatalf("expected error containing %q, got %v", tt.wantErrorSubstring, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseImagesFromJSON() error = %v", err)
+			}
+			if gotPackage != tt.wantPackage {
+				t.Errorf("package = %q, want %q", gotPackage, tt.wantPackage)
+			}
+			if (gotController == nil) != (tt.wantController == nil) {
+				t.Fatalf("controller nil = %t, want %t", gotController == nil, tt.wantController == nil)
+			}
+			if gotController != nil && *gotController != *tt.wantController {
+				t.Errorf("controller = %q, want %q", *gotController, *tt.wantController)
+			}
+		})
+	}
+}

--- a/test/upgrade/image_layout.go
+++ b/test/upgrade/image_layout.go
@@ -18,6 +18,10 @@ const (
 	firstSingleImageVersion = "1.0.1"
 )
 
+// firstSingleImageSemver is parsed once at init so invalid cutoffs fail
+// immediately rather than on first layout resolution.
+var firstSingleImageSemver = mustParseSemver(firstSingleImageVersion)
+
 type imageLayout struct {
 	packageImage    string
 	controllerImage *string
@@ -41,16 +45,19 @@ func resolveImageLayout(tag, localPackage string, localController *string, packa
 // tags (for example commit or channel tags) are assumed to refer to the
 // current single-image build; layout detection never depends on a failed pull.
 func isSingleImageVersion(tag string) bool {
-	threshold, err := semver.Parse(firstSingleImageVersion)
-	if err != nil {
-		panic(fmt.Errorf("invalid single-image version cutoff %q: %w", firstSingleImageVersion, err))
-	}
-
 	version, err := semver.Parse(strings.TrimPrefix(tag, "v"))
 	if err != nil {
 		return true
 	}
-	return version.GTE(threshold)
+	return version.GTE(firstSingleImageSemver)
+}
+
+func mustParseSemver(version string) semver.Version {
+	v, err := semver.Parse(version)
+	if err != nil {
+		panic(fmt.Errorf("invalid single-image version cutoff %q: %w", version, err))
+	}
+	return v
 }
 
 func providerInstallOptions(providerName string, layout imageLayout) xpenvfuncs.InstallCrossplaneProviderOptions {

--- a/test/upgrade/image_layout.go
+++ b/test/upgrade/image_layout.go
@@ -1,0 +1,95 @@
+package upgrade
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/blang/semver/v4"
+	"github.com/crossplane-contrib/xp-testing/pkg/xpenvfuncs"
+)
+
+// firstSingleImageVersion is the first Cloud Foundry release using the
+// single-image package layout. Repository tag contents show v1.0.0 retaining
+// a separate controller and v1.0.1 using the single-image layout. Non-semver
+// registry tags are treated as current single-image builds, rather than using
+// a failed controller pull to detect the layout.
+const (
+	localTagName            = "local"
+	firstSingleImageVersion = "1.0.1"
+)
+
+type imageLayout struct {
+	packageImage    string
+	controllerImage *string
+}
+
+func resolveImageLayout(tag, localPackage string, localController *string, packageRepository, controllerRepository string) imageLayout {
+	if tag == localTagName {
+		return imageLayout{packageImage: localPackage, controllerImage: localController}
+	}
+
+	packageImage := fmt.Sprintf("%s:%s", packageRepository, tag)
+	if isSingleImageVersion(tag) {
+		return imageLayout{packageImage: packageImage}
+	}
+
+	controllerImage := fmt.Sprintf("%s:%s", controllerRepository, tag)
+	return imageLayout{packageImage: packageImage, controllerImage: &controllerImage}
+}
+
+// isSingleImageVersion uses the documented v1.0.1 layout cutoff. Non-semver
+// tags (for example commit or channel tags) are assumed to refer to the
+// current single-image build; layout detection never depends on a failed pull.
+func isSingleImageVersion(tag string) bool {
+	threshold, err := semver.Parse(firstSingleImageVersion)
+	if err != nil {
+		panic(fmt.Errorf("invalid single-image version cutoff %q: %w", firstSingleImageVersion, err))
+	}
+
+	version, err := semver.Parse(strings.TrimPrefix(tag, "v"))
+	if err != nil {
+		return true
+	}
+	return version.GTE(threshold)
+}
+
+func providerInstallOptions(providerName string, layout imageLayout) xpenvfuncs.InstallCrossplaneProviderOptions {
+	return xpenvfuncs.InstallCrossplaneProviderOptions{
+		Name:            providerName,
+		Package:         layout.packageImage,
+		ControllerImage: layout.controllerImage,
+	}
+}
+
+func imageNames(layout imageLayout) []string {
+	images := []string{layout.packageImage}
+	if layout.controllerImage != nil {
+		images = append(images, *layout.controllerImage)
+	}
+	return images
+}
+
+func localPackageImagesToLoad(fromTag, toTag string, from, to imageLayout) []string {
+	var images []string
+	if fromTag == localTagName {
+		images = append(images, from.packageImage)
+	}
+	if toTag == localTagName && (fromTag != localTagName || to.packageImage != from.packageImage) {
+		images = append(images, to.packageImage)
+	}
+	return images
+}
+
+// registryImagesToLoad returns the exact registry images that must be loaded.
+// The TO side is skipped when its tag equals FROM, preserving the existing
+// no-duplicate load behavior.
+func registryImagesToLoad(fromTag, toTag string, from, to imageLayout) []string {
+	var images []string
+	if fromTag != localTagName {
+		images = append(images, imageNames(from)...)
+	}
+	if toTag != localTagName && toTag != fromTag {
+		images = append(images, imageNames(to)...)
+	}
+	return images
+}

--- a/test/upgrade/image_layout_test.go
+++ b/test/upgrade/image_layout_test.go
@@ -1,0 +1,145 @@
+package upgrade
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestResolveImageLayout(t *testing.T) {
+	localController := "local/controller:latest"
+	tests := map[string]struct {
+		tag               string
+		localPackage      string
+		localController   *string
+		wantPackage       string
+		wantController    *string
+		packageRepository string
+		controllerRepo    string
+	}{
+		"local single image": {
+			tag:               localTagName,
+			localPackage:      "local/provider-xpkg:latest",
+			wantPackage:       "local/provider-xpkg:latest",
+			packageRepository: "registry/provider",
+			controllerRepo:    "registry/controller",
+		},
+		"local two images": {
+			tag:               localTagName,
+			localPackage:      "local/provider:latest",
+			localController:   &localController,
+			wantPackage:       "local/provider:latest",
+			wantController:    &localController,
+			packageRepository: "registry/provider",
+			controllerRepo:    "registry/controller",
+		},
+		"old registry tag": {
+			tag:               "v1.0.0",
+			wantPackage:       "registry/provider:v1.0.0",
+			wantController:    stringPointer("registry/controller:v1.0.0"),
+			packageRepository: "registry/provider",
+			controllerRepo:    "registry/controller",
+		},
+		"new registry tag": {
+			tag:               "v1.0.1",
+			wantPackage:       "registry/provider:v1.0.1",
+			packageRepository: "registry/provider",
+			controllerRepo:    "registry/controller",
+		},
+		"non-semver registry tag": {
+			tag:               "latest",
+			wantPackage:       "registry/provider:latest",
+			packageRepository: "registry/provider",
+			controllerRepo:    "registry/controller",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := resolveImageLayout(tt.tag, tt.localPackage, tt.localController, tt.packageRepository, tt.controllerRepo)
+			if got.packageImage != tt.wantPackage {
+				t.Errorf("package image = %q, want %q", got.packageImage, tt.wantPackage)
+			}
+			if !reflect.DeepEqual(got.controllerImage, tt.wantController) {
+				t.Errorf("controller image = %v, want %v", got.controllerImage, tt.wantController)
+			}
+		})
+	}
+}
+
+func TestProviderInstallOptionsControllerImage(t *testing.T) {
+	controller := "registry/controller:v1.0.0"
+
+	legacy := providerInstallOptions("provider-cloudfoundry", imageLayout{
+		packageImage:    "registry/provider:v1.0.0",
+		controllerImage: &controller,
+	})
+	if legacy.ControllerImage == nil || *legacy.ControllerImage != controller {
+		t.Fatalf("legacy controller image = %v, want %q", legacy.ControllerImage, controller)
+	}
+
+	single := providerInstallOptions("provider-cloudfoundry", imageLayout{packageImage: "registry/provider:v1.0.1"})
+	if single.ControllerImage != nil {
+		t.Fatalf("single-image controller image = %q, want nil", *single.ControllerImage)
+	}
+}
+
+func TestLocalPackageImagesToLoad(t *testing.T) {
+	single := imageLayout{packageImage: "local/provider-xpkg:latest"}
+
+	if got := localPackageImagesToLoad(localTagName, "v1.0.0", single, imageLayout{}); !reflect.DeepEqual(got, []string{single.packageImage}) {
+		t.Fatalf("local FROM package images = %v, want %v", got, []string{single.packageImage})
+	}
+	if got := localPackageImagesToLoad("v1.0.0", localTagName, imageLayout{}, single); !reflect.DeepEqual(got, []string{single.packageImage}) {
+		t.Fatalf("local TO package images = %v, want %v", got, []string{single.packageImage})
+	}
+	if got := localPackageImagesToLoad(localTagName, localTagName, single, single); !reflect.DeepEqual(got, []string{single.packageImage}) {
+		t.Fatalf("same local package images = %v, want %v", got, []string{single.packageImage})
+	}
+}
+
+func TestRegistryImagesToLoadCrossLayouts(t *testing.T) {
+	legacyController := "registry/controller:v1.0.0"
+	legacy := imageLayout{packageImage: "registry/provider:v1.0.0", controllerImage: &legacyController}
+	single := imageLayout{packageImage: "registry/provider:v1.0.1"}
+
+	tests := map[string]struct {
+		fromTag string
+		toTag   string
+		from    imageLayout
+		to      imageLayout
+		want    []string
+	}{
+		"legacy to single": {
+			fromTag: "v1.0.0", toTag: "v1.0.1",
+			from: legacy, to: single,
+			want: []string{"registry/provider:v1.0.0", "registry/controller:v1.0.0", "registry/provider:v1.0.1"},
+		},
+		"single to legacy": {
+			fromTag: "v1.0.1", toTag: "v1.0.0",
+			from: single, to: legacy,
+			want: []string{"registry/provider:v1.0.1", "registry/provider:v1.0.0", "registry/controller:v1.0.0"},
+		},
+		"same tag no duplicate TO load": {
+			fromTag: "v1.0.1", toTag: "v1.0.1",
+			from: single, to: single,
+			want: []string{"registry/provider:v1.0.1"},
+		},
+		"local to registry": {
+			fromTag: localTagName, toTag: "v1.0.1",
+			from: imageLayout{packageImage: "local/provider-xpkg:latest"}, to: single,
+			want: []string{"registry/provider:v1.0.1"},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := registryImagesToLoad(tt.fromTag, tt.toTag, tt.from, tt.to); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("registryImagesToLoad() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func stringPointer(value string) *string {
+	return &value
+}

--- a/test/upgrade/main_test.go
+++ b/test/upgrade/main_test.go
@@ -68,7 +68,6 @@ const (
 	defaultResourceDirectory = "./testdata/baseCrs"
 	defaultVerifyTimeout     = 30
 	defaultWaitForPause      = 1
-	localTagName             = "local"
 )
 
 var (
@@ -87,12 +86,10 @@ var (
 )
 
 var (
-	fromTag               string
-	toTag                 string
-	fromPackage           string
-	toPackage             string
-	fromControllerPackage string
-	toControllerPackage   string
+	fromTag    string
+	toTag      string
+	fromLayout imageLayout
+	toLayout   imageLayout
 )
 
 // TestMain is the entry point for all upgrade tests
@@ -127,11 +124,12 @@ func SetupClusterWithCrossplane(namespace string) {
 	loadResourceDirectories()
 	klog.V(4).Infof("found resource directories: %s", resourceDirectories)
 
-	// Resolve image paths (handles both "local" and registry tags)
-	fromPackage, fromControllerPackage, toPackage, toControllerPackage = resolveImagePaths(fromTag, toTag)
+	// Resolve image layouts independently (handles local and registry tags).
+	fromLayout, toLayout = resolveImagePaths(fromTag, toTag)
 
-	// Pull images from registry if needed (skip if local)
-	pullImagesIfNeeded(fromTag, toTag, fromPackage, fromControllerPackage, toPackage, toControllerPackage)
+	// Pull images from registry if needed (skip if local). Controller images are
+	// optional for single-image layouts.
+	pullImagesIfNeeded(fromTag, toTag, fromLayout, toLayout)
 
 	// Configure provider deployment with debug logging and faster sync
 	deploymentRuntimeConfig := getDeploymentRuntimeConfig()
@@ -140,8 +138,8 @@ func SetupClusterWithCrossplane(namespace string) {
 	cfg := setup.ClusterSetup{
 		ProviderName: providerName,
 		Images: images.ProviderImages{
-			Package:         fromPackage,
-			ControllerImage: &fromControllerPackage,
+			Package:         fromLayout.packageImage,
+			ControllerImage: fromLayout.controllerImage,
 		},
 		CrossplaneSetup: setup.CrossplaneSetup{
 			Version:  crossplaneVersion,
@@ -155,9 +153,14 @@ func SetupClusterWithCrossplane(namespace string) {
 		kindClusterName = clusterName
 		return func(ctx context.Context, config *envconf.Config) (context.Context, error) {
 			klog.V(4).Infof("upgrade cluster %s has been created", clusterName)
-			// Load registry images into kind (xp-testing uses PackagePullPolicy: Never)
-			// Local images are already loaded by xp-testing automatically
-			if err := loadRegistryImagesIntoKind(clusterName, fromTag, toTag); err != nil {
+			// xp-testing copies local package metadata into Crossplane's cache but
+			// does not load the local xpkg image when ControllerImage is nil. Load
+			// the package image explicitly; this is not a controller-image load.
+			if err := loadLocalPackageImagesIntoKind(clusterName, fromTag, toTag, fromLayout, toLayout); err != nil {
+				return ctx, fmt.Errorf("failed to load local package images into kind: %w", err)
+			}
+			// Load registry images into kind (xp-testing uses PackagePullPolicy: Never).
+			if err := loadRegistryImagesIntoKind(clusterName, fromTag, toTag, fromLayout, toLayout); err != nil {
 				return ctx, fmt.Errorf("failed to load registry images into kind: %w", err)
 			}
 			return ctx, nil
@@ -173,104 +176,81 @@ func SetupClusterWithCrossplane(namespace string) {
 	)
 }
 
-// resolveImagePaths determines the correct image paths for FROM and TO versions
-// based on whether they're using "local" builds or registry tags
-func resolveImagePaths(fromTag, toTag string) (fromPkg, fromCtrl, toPkg, toCtrl string) {
+// resolveImagePaths determines the correct package-plus-optional-controller
+// layout independently for FROM and TO versions.
+func resolveImagePaths(fromTag, toTag string) (imageLayout, imageLayout) {
 	isLocalFromTag := fromTag == localTagName
 	isLocalToTag := toTag == localTagName
 
-	// Get local image paths if needed
-	var localProviderPackage, localControllerPackage string
+	var localPackage string
+	var localController *string
 	if isLocalFromTag || isLocalToTag {
 		uutImages := os.Getenv(uutImagesEnvVar)
 		if uutImages == "" {
 			panic(fmt.Errorf("%s environment variable is required when FROM_TAG or TO_TAG is 'local'", uutImagesEnvVar))
 		}
 
-		localProviderPackage, localControllerPackage = testutil.GetImagesFromJsonOrPanic(uutImages)
+		localPackage, localController = testutil.GetImagesFromJsonOrPanic(uutImages)
 		klog.V(4).Infof("Loaded local images from %s", uutImagesEnvVar)
 	}
 
-	// Resolve FROM images
+	from := resolveImageLayout(fromTag, localPackage, localController, packageBasePath, controllerPackageBasePath)
+	to := resolveImageLayout(toTag, localPackage, localController, packageBasePath, controllerPackageBasePath)
 	if isLocalFromTag {
-		fromPkg = localProviderPackage
-		fromCtrl = localControllerPackage
-		klog.V(4).Infof("Using local images for FROM: %s", fromPkg)
-	} else {
-		fromPkg = fmt.Sprintf("%s:%s", packageBasePath, fromTag)
-		fromCtrl = fmt.Sprintf("%s:%s", controllerPackageBasePath, fromTag)
+		klog.V(4).Infof("Using local images for FROM: %s", from.packageImage)
 	}
-
-	// Resolve TO images
 	if isLocalToTag {
-		toPkg = localProviderPackage
-		toCtrl = localControllerPackage
-		klog.V(4).Infof("Using local images for TO: %s", toPkg)
-	} else {
-		toPkg = fmt.Sprintf("%s:%s", packageBasePath, toTag)
-		toCtrl = fmt.Sprintf("%s:%s", controllerPackageBasePath, toTag)
+		klog.V(4).Infof("Using local images for TO: %s", to.packageImage)
 	}
 
-	return fromPkg, fromCtrl, toPkg, toCtrl
+	return from, to
 }
 
-// pullImagesIfNeeded pulls images from registry if they're not local builds
-// Local images are already built by the Makefile and don't need pulling
-func pullImagesIfNeeded(fromTag, toTag, fromPackage, fromControllerPackage, toPackage, toControllerPackage string) {
-	// Pull FROM images if not local
-	if fromTag != localTagName {
-		klog.V(4).Infof("Pulling FROM images: %s", fromTag)
-		mustPullImage(fromPackage)
-		mustPullImage(fromControllerPackage)
-		klog.V(4).Infof("Successfully pulled FROM images: %s", fromTag)
-	} else {
-		klog.V(4).Infof("Skipping pull for FROM=local (using locally built images)")
-	}
-
-	// Pull TO images if not local
-	if toTag != localTagName {
-		klog.V(4).Infof("Pulling TO images: %s", toTag)
-		mustPullImage(toPackage)
-		mustPullImage(toControllerPackage)
-		klog.V(4).Infof("Successfully pulled TO images: %s", toTag)
-	} else {
-		klog.V(4).Infof("Skipping pull for TO=local (using locally built images)")
+// pullImagesIfNeeded pulls only the images resolved for each registry side.
+func pullImagesIfNeeded(fromTag, toTag string, from, to imageLayout) {
+	for _, side := range []struct {
+		tag    string
+		name   string
+		images imageLayout
+	}{
+		{fromTag, "FROM", from},
+		{toTag, "TO", to},
+	} {
+		if side.tag == localTagName {
+			klog.V(4).Infof("Skipping pull for %s=local (using locally built images)", side.name)
+			continue
+		}
+		klog.V(4).Infof("Pulling %s images: %s", side.name, side.tag)
+		for _, image := range imageNames(side.images) {
+			mustPullImage(image)
+		}
+		klog.V(4).Infof("Successfully pulled %s images: %s", side.name, side.tag)
 	}
 }
 
-// loadRegistryImagesIntoKind loads pulled registry images into the kind cluster
-// xp-testing uses PackagePullPolicy: Never, so all images must be pre-loaded
-func loadRegistryImagesIntoKind(clusterName, fromTag, toTag string) error {
+// loadLocalPackageImagesIntoKind loads local xpkg images into kind. The
+// package image must be available because ControllerImage is nil for a
+// single-image layout and xp-testing otherwise only copies its descriptor.
+func loadLocalPackageImagesIntoKind(clusterName, fromTag, toTag string, from, to imageLayout) error {
 	runner := gexe.New()
-
-	// Load FROM images if they're from a registry
-	if fromTag != localTagName {
-		klog.V(4).Infof("Loading FROM images into kind: %s", fromPackage)
-
-		if err := loadImageIntoKind(runner, clusterName, fromPackage); err != nil {
+	for _, image := range localPackageImagesToLoad(fromTag, toTag, from, to) {
+		if err := loadImageIntoKind(runner, clusterName, image); err != nil {
 			return err
 		}
-		if err := loadImageIntoKind(runner, clusterName, fromControllerPackage); err != nil {
-			return err
-		}
-
-		klog.V(4).Infof("Successfully loaded FROM images into kind")
 	}
+	return nil
+}
 
-	// Load TO images if they're from a registry and different from FROM
-	if toTag != localTagName && toTag != fromTag {
-		klog.V(4).Infof("Loading TO images into kind: %s", toPackage)
-
-		if err := loadImageIntoKind(runner, clusterName, toPackage); err != nil {
+// loadRegistryImagesIntoKind loads pulled registry images into the kind cluster.
+// xp-testing uses PackagePullPolicy: Never, so all resolved images must be
+// pre-loaded.
+func loadRegistryImagesIntoKind(clusterName, fromTag, toTag string, from, to imageLayout) error {
+	runner := gexe.New()
+	for _, image := range registryImagesToLoad(fromTag, toTag, from, to) {
+		if err := loadImageIntoKind(runner, clusterName, image); err != nil {
 			return err
 		}
-		if err := loadImageIntoKind(runner, clusterName, toControllerPackage); err != nil {
-			return err
-		}
-
-		klog.V(4).Infof("Successfully loaded TO images into kind")
 	}
-
 	return nil
 }
 

--- a/test/upgrade/upgrade_test_framework.go
+++ b/test/upgrade/upgrade_test_framework.go
@@ -18,7 +18,6 @@ import (
 	"github.com/SAP/crossplane-provider-cloudfoundry/apis/v1beta1"
 	"github.com/SAP/crossplane-provider-cloudfoundry/test"
 	"github.com/crossplane-contrib/xp-testing/pkg/upgrade"
-	"github.com/crossplane-contrib/xp-testing/pkg/xpenvfuncs"
 	kubeErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	res "sigs.k8s.io/e2e-framework/klient/k8s/resources"
@@ -187,21 +186,24 @@ func (b *CustomUpgradeTestBuilder) Feature() features.Feature {
 		panic("Both fromTag and toTag must be specified before building an upgrade test feature")
 	}
 
-	fromProviderPackage, toProviderPackage := loadPackages(b.fromTag, b.toTag)
+	fromLayout, toLayout := loadPackages(b.fromTag, b.toTag)
 
 	upgradeTest := upgrade.UpgradeTest{
 		ProviderName:        providerName,
 		ClusterName:         kindClusterName,
-		FromProviderPackage: fromProviderPackage,
-		ToProviderPackage:   toProviderPackage,
+		FromProviderPackage: fromLayout.packageImage,
+		ToProviderPackage:   toLayout.packageImage,
 		ResourceDirectories: b.resourceDirectories,
 	}
+
+	fromProviderOptions := providerInstallOptions(providerName, fromLayout)
+	toProviderOptions := providerInstallOptions(providerName, toLayout)
 
 	featureName := fmt.Sprintf("%s: Upgrade %s from %s to %s", b.testName, providerName, b.fromTag, b.toTag)
 	feature := features.New(featureName).
 		WithSetup(
 			"Install provider with version "+b.fromTag,
-			upgrade.ApplyProvider(upgradeTest.ClusterName, upgradeTest.FromProviderInstallOptions()),
+			upgrade.ApplyProvider(upgradeTest.ClusterName, fromProviderOptions),
 		).
 		WithSetup(
 			"Apply ProviderConfig",
@@ -227,11 +229,8 @@ func (b *CustomUpgradeTestBuilder) Feature() features.Feature {
 	feature = feature.Assess(
 		"Upgrade provider to version "+b.toTag,
 		upgrade.UpgradeProvider(upgrade.UpgradeProviderOptions{
-			ClusterName: upgradeTest.ClusterName,
-			ProviderOptions: xpenvfuncs.InstallCrossplaneProviderOptions{
-				Name:    providerName,
-				Package: upgradeTest.ToProviderPackage,
-			},
+			ClusterName:         upgradeTest.ClusterName,
+			ProviderOptions:     toProviderOptions,
 			ResourceDirectories: upgradeTest.ResourceDirectories,
 			WaitForPause:        b.waitForPause,
 		}),
@@ -274,11 +273,8 @@ func (b *CustomUpgradeTestBuilder) Feature() features.Feature {
 	return feature.Feature()
 }
 
-func loadPackages(fromTag, toTag string) (string, string) {
-	return test.LoadUpgradePackages(
-		fromTag, toTag,
-		fromPackage, toPackage,
-	)
+func loadPackages(fromTag, toTag string) (imageLayout, imageLayout) {
+	return resolveImagePaths(fromTag, toTag)
 }
 
 // Helper to get ProviderConfig setup function

--- a/test/upgrade/upgrade_test_framework.go
+++ b/test/upgrade/upgrade_test_framework.go
@@ -186,7 +186,7 @@ func (b *CustomUpgradeTestBuilder) Feature() features.Feature {
 		panic("Both fromTag and toTag must be specified before building an upgrade test feature")
 	}
 
-	fromLayout, toLayout := loadPackages(b.fromTag, b.toTag)
+	fromLayout, toLayout := resolveImagePaths(b.fromTag, b.toTag)
 
 	upgradeTest := upgrade.UpgradeTest{
 		ProviderName:        providerName,
@@ -271,10 +271,6 @@ func (b *CustomUpgradeTestBuilder) Feature() features.Feature {
 	)
 
 	return feature.Feature()
-}
-
-func loadPackages(fromTag, toTag string) (imageLayout, imageLayout) {
-	return resolveImagePaths(fromTag, toTag)
 }
 
 // Helper to get ProviderConfig setup function


### PR DESCRIPTION
## Summary

- Support local upgrade tests with single-image provider packages.
- Preserve compatibility with legacy two-image provider layouts.
- Skip pulling/loading optional controller images when absent.
- Add image-layout resolution and focused unit tests.
- Add local package-image loading support for kind.

## Validation

- Local upgrade test completed successfully.
- Added unit tests for single-image and two-image layouts.
