### PR TITLE
Remove invalid lifecycle parameter in route

### DIFF
--- a/docs/end-user-guides/deploy-workload-provider-cf.mdx
+++ b/docs/end-user-guides/deploy-workload-provider-cf.mdx
@@ -343,7 +343,6 @@ spec:
     routes:
     - routeRef:
         name: my-route
-        lifecycle: docker
     processes:
     - type: web
       diskQuota: "512MB"


### PR DESCRIPTION
Running the given App crd in the materials returns an error because of an invalid schema.
Somehow the lifecycle param has sneaked into to route which does not exist based on the official [doc].(https://doc.crds.dev/github.com/SAP/crossplane-provider-cloudfoundry/cloudfoundry.crossplane.io/App/v1alpha1@v1.0.0#spec-forProvider-routes-route)

Removing the line as in the PR solves the problem.